### PR TITLE
fix: use correct field name for Alive/Not Alive stats count

### DIFF
--- a/hooks/table/useStats.ts
+++ b/hooks/table/useStats.ts
@@ -28,10 +28,10 @@ export function useStats<TableDataType>({
                 if (row.assignedAsha && row.assignedAsha !== 'none') stats.assigned++
                 else stats.unassigned++
 
-                if ((row.status || '').toLowerCase() === 'alive') stats.alive++
+                // The field in Firestore is "patientStatus", not "status"
+                if ((row.patientStatus || '').toLowerCase() === 'alive') stats.alive++
                 else if (
-                    (row.status || '').toLowerCase() === 'death' ||
-                    (row.status || '').toLowerCase() === 'not alive'
+                    (row.patientStatus || '').toLowerCase() === 'not alive'
                 ) stats.deceased++
             }
             if (!isHospitalTab) {


### PR DESCRIPTION
Closes #100

## The Bug

The bottom stats bar was showing `Alive: 0` and `Not Alive: 0` for all patients, even though the table clearly had patients with both statuses. Total, Male, Female, Assigned, and Unassigned counts were all working fine.

## Root Cause

Classic field name mismatch in `hooks/table/useStats.ts`. The stats hook was reading `row.status`, but the actual Firestore field (defined in `PatientSchema`) is `row.patientStatus`.

So `row.status` was always `undefined`, and `(undefined || '').toLowerCase()` is just `''` — which never matches `'alive'` or `'not alive'`. Both counters stayed at 0.

## The Fix

**One-line fix** in `hooks/table/useStats.ts`:

```diff
- if ((row.status || '').toLowerCase() === 'alive') stats.alive++
- else if (
-     (row.status || '').toLowerCase() === 'death' ||
-     (row.status || '').toLowerCase() === 'not alive'
- ) stats.deceased++
+ // The field in Firestore is "patientStatus", not "status"
+ if ((row.patientStatus || '').toLowerCase() === 'alive') stats.alive++
+ else if (
+     (row.patientStatus || '').toLowerCase() === 'not alive'
+ ) stats.deceased++
```
I also removed the 'death' check — looking at the PatientSchema, the enum is ['Alive', 'Not Alive', 'Not Available']. There's no 'death' value in the schema, so that condition could never be true. Keeping dead code around is confusing for future contributors.