### PR TITLE
fix(lint): make ESLint config compatible with Next.js 16

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,20 +1,13 @@
-// For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+import nextTs from 'eslint-config-next/typescript'
 import storybook from 'eslint-plugin-storybook'
 
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-})
-
-const eslintConfig = [
-    ...compat.extends('next/core-web-vitals', 'next/typescript'),
+const eslintConfig = defineConfig([
+    ...nextVitals,
+    ...nextTs,
     ...storybook.configs['flat/recommended'],
-]
+    globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
+])
 
 export default eslintConfig

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "dev": "next dev --webpack",
         "build": "next build --webpack",
         "start": "next start",
-        "lint": "next lint",
+        "lint": "eslint .",
         "test": "vitest",
         "prepare": "husky",
         "seed:users": "node scripts/seedUsers.mjs",


### PR DESCRIPTION
- Drop FlatCompat (cause of circular-structure crash on lint).
- Use the native flat-config exports from eslint-config-next@16 (/core-web-vitals, /typescript) plus ESLint 9's defineConfig and globalIgnores helpers.
- Update the "lint" script: `next lint` was removed in Next.js 16; the official replacement is `eslint .`.

`pnpm lint` now runs cleanly and surfaces real lint feedback (57 pre-existing errors, 67 warnings) for follow-up. Tests unchanged: 39/39 passing.