### PR TITLE
Improve patient filter UI scalability and UX

### DIFF
--- a/components/table/PatientFilter.tsx
+++ b/components/table/PatientFilter.tsx
@@ -14,11 +14,11 @@ import {
     SheetFooter,
 } from '@/components/ui/sheet'
 import {
-    DISEASE_OPTIONS,
     HEALTH_STATUS_OPTIONS,
     RATION_COLORS_OPTIONS,
     SEX_OPTIONS,
 } from '@/constants/form-fields'
+import { AVAILABLE_DISEASES_LIST } from '@/constants/diseases'
 import { usePatientFilterStore } from '@/store/patient-filter-store'
 import { ListFilter, X, RotateCcw } from 'lucide-react'
 import { useMemo } from 'react'
@@ -128,7 +128,9 @@ export function PatientFilter() {
                                 </h4>
                                 <FilterSection
                                     label="Disease"
-                                    options={DISEASE_OPTIONS.map((opt) => ({ label: opt, value: opt }))}
+                                    options={Object.values(AVAILABLE_DISEASES_LIST)
+                                        .flat()
+                                        .map((d) => ({ label: d.label, value: d.label.toLowerCase() }))}
                                     selected={filters.diseases}
                                     onToggle={(val) => toggleFilterItem('diseases', val)}
                                     onClear={() => setFilter('diseases', [])}

--- a/components/table/PatientFilter.tsx
+++ b/components/table/PatientFilter.tsx
@@ -3,9 +3,16 @@
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+    SheetFooter,
+} from '@/components/ui/sheet'
 import {
     DISEASE_OPTIONS,
     HEALTH_STATUS_OPTIONS,
@@ -50,9 +57,9 @@ export function PatientFilter() {
 
     return (
         <div className="flex flex-col gap-4 md:flex-row md:items-center">
-            <Popover>
-                <PopoverTrigger asChild>
-                    <Button className="relative cursor-pointer" variant="outline">
+            <Sheet>
+                <SheetTrigger asChild>
+                    <Button className="cursor-pointer" variant="outline">
                         <ListFilter className="mr-1 h-4 w-4" />
                         <span className="hidden md:inline">Filters</span>
                         {activeFilterCount > 0 && (
@@ -61,35 +68,39 @@ export function PatientFilter() {
                             </span>
                         )}
                     </Button>
-                </PopoverTrigger>
+                </SheetTrigger>
 
-                <PopoverContent className="w-[320px] sm:w-[480px] p-0 shadow-xl" align="end">
-                    <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/30">
-                        <h3 className="font-semibold text-sm flex items-center gap-2">
-                            <ListFilter className="h-4 w-4" />
-                            Filters
-                        </h3>
-                        {activeFilterCount > 0 && (
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={reset}
-                                className="h-8 px-2 text-xs text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-                            >
-                                <RotateCcw className="mr-1.5 h-3 w-3" />
-                                Clear All
-                            </Button>
-                        )}
-                    </div>
+                <SheetContent side="right" className="w-full sm:max-w-md flex flex-col p-0 overflow-hidden border-l shadow-2xl">
+                    <SheetHeader className="px-6 py-5 border-b bg-muted/30">
+                        <div className="flex items-center justify-between">
+                            <SheetTitle className="text-xl flex items-center gap-2">
+                                <ListFilter className="h-5 w-5" />
+                                Patient Filters
+                            </SheetTitle>
+                            {activeFilterCount > 0 && (
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={reset}
+                                    className="h-8 px-3 text-xs text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                                >
+                                    <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                                    Clear All
+                                </Button>
+                            )}
+                        </div>
+                    </SheetHeader>
 
-                    <ScrollArea className="h-[400px] sm:h-[500px]">
-                        <div className="p-4 space-y-8">
+                    <ScrollArea className="flex-1 overflow-y-auto">
+                        <div className="px-6 py-8 space-y-10">
                             {/* Demographics Group */}
-                            <div className="space-y-4">
-                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
+                            <div className="space-y-5">
+                                <h4 className="text-[12px] font-bold uppercase tracking-widest text-muted-foreground/60 flex items-center gap-2">
+                                    <span className="h-px flex-1 bg-border/40" />
                                     Demographics
+                                    <span className="h-px flex-1 bg-border/40" />
                                 </h4>
-                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6">
+                                <div className="space-y-8">
                                     <FilterSection
                                         label="Sex"
                                         options={SEX_OPTIONS.map((opt) => ({ label: opt, value: opt }))}
@@ -108,12 +119,12 @@ export function PatientFilter() {
                                 </div>
                             </div>
 
-                            <div className="h-px bg-border/50 mx-1" />
-
                             {/* Medical Group */}
-                            <div className="space-y-4">
-                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
+                            <div className="space-y-5">
+                                <h4 className="text-[12px] font-bold uppercase tracking-widest text-muted-foreground/60 flex items-center gap-2">
+                                    <span className="h-px flex-1 bg-border/40" />
                                     Medical
+                                    <span className="h-px flex-1 bg-border/40" />
                                 </h4>
                                 <FilterSection
                                     label="Disease"
@@ -125,22 +136,22 @@ export function PatientFilter() {
                                 />
                             </div>
 
-                            <div className="h-px bg-border/50 mx-1" />
-
                             {/* Status Group */}
-                            <div className="space-y-4">
-                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
-                                    Patient Status
+                            <div className="space-y-5">
+                                <h4 className="text-[12px] font-bold uppercase tracking-widest text-muted-foreground/60 flex items-center gap-2">
+                                    <span className="h-px flex-1 bg-border/40" />
+                                    Care Status
+                                    <span className="h-px flex-1 bg-border/40" />
                                 </h4>
-                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6">
+                                <div className="space-y-8">
                                     <FilterSection
-                                        label="Status"
+                                        label="Patient Status"
                                         options={HEALTH_STATUS_OPTIONS.map((opt) => ({ label: opt, value: opt }))}
                                         selected={filters.statuses}
                                         onToggle={(val) => toggleFilterItem('statuses', val)}
                                         onClear={() => setFilter('statuses', [])}
                                     />
-                                    <div className="space-y-6">
+                                    <div className="grid grid-cols-2 gap-6">
                                         <FilterSection
                                             label="Assignment"
                                             type="radio"
@@ -161,12 +172,12 @@ export function PatientFilter() {
                                 </div>
                             </div>
 
-                            <div className="h-px bg-border/50 mx-1" />
-
                             {/* Government Group */}
-                            <div className="space-y-4 pb-2">
-                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
+                            <div className="space-y-5 pb-4">
+                                <h4 className="text-[12px] font-bold uppercase tracking-widest text-muted-foreground/60 flex items-center gap-2">
+                                    <span className="h-px flex-1 bg-border/40" />
                                     Government
+                                    <span className="h-px flex-1 bg-border/40" />
                                 </h4>
                                 <FilterSection
                                     label="Ration Card"
@@ -178,15 +189,16 @@ export function PatientFilter() {
                             </div>
                         </div>
                     </ScrollArea>
-                    <div className="p-3 border-t bg-muted/10 flex justify-end">
-                        <PopoverTrigger asChild>
-                            <Button size="sm" className="h-8 px-4 text-xs font-medium">
-                                Apply Filters
+
+                    <SheetFooter className="p-6 border-t bg-muted/10 gap-3 sm:flex-col">
+                        <SheetTrigger asChild>
+                            <Button className="w-full font-semibold">
+                                Apply & Close
                             </Button>
-                        </PopoverTrigger>
-                    </div>
-                </PopoverContent>
-            </Popover>
+                        </SheetTrigger>
+                    </SheetFooter>
+                </SheetContent>
+            </Sheet>
         </div>
     )
 }

--- a/components/table/PatientFilter.tsx
+++ b/components/table/PatientFilter.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import {
     DISEASE_OPTIONS,
     HEALTH_STATUS_OPTIONS,
@@ -11,68 +13,177 @@ import {
     SEX_OPTIONS,
 } from '@/constants/form-fields'
 import { usePatientFilterStore } from '@/store/patient-filter-store'
-import { ListFilter } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import { ListFilter, X, RotateCcw } from 'lucide-react'
+import { useMemo } from 'react'
+import { cn } from '@/lib/utils'
+
+const AGE_OPTIONS = [
+    { label: 'Under 5 years', value: 'lt5' },
+    { label: 'Under 20 years', value: 'lt20' },
+    { label: 'Over 50 years', value: 'gt50' },
+]
+
+const ASSIGNED_OPTIONS = [
+    { label: 'Assigned', value: 'assigned' },
+    { label: 'Unassigned', value: 'unassigned' },
+]
+
+const TRANSFER_OPTIONS = [
+    { label: 'Transferred', value: 'transferred' },
+    { label: 'Not Transferred', value: 'not_transferred' },
+]
 
 export function PatientFilter() {
-    const searchRef = useRef<HTMLInputElement>(null)
     const { filters, setFilter, toggleFilterItem, reset } = usePatientFilterStore()
 
-    useEffect(() => {
-        const handleKey = (e: KeyboardEvent) => {
-            if (e.ctrlKey && e.key.toLowerCase() === 'k') {
-                e.preventDefault()
-                searchRef.current?.focus()
-            }
-        }
-        window.addEventListener('keydown', handleKey)
-        return () => window.removeEventListener('keydown', handleKey)
-    }, [])
+    const activeFilterCount = useMemo(() => {
+        let count = 0
+        count += filters.sexes.length
+        count += filters.diseases.length
+        count += filters.statuses.length
+        count += filters.rationColors.length
+        if (filters.age) count++
+        if (filters.assigned) count++
+        if (filters.transfer) count++
+        return count
+    }, [filters])
 
     return (
         <div className="flex flex-col gap-4 md:flex-row md:items-center">
-            {/* Filters */}
             <Popover>
                 <PopoverTrigger asChild>
-                    <Button className="cursor-pointer" variant="outline">
+                    <Button className="relative cursor-pointer" variant="outline">
                         <ListFilter className="mr-1 h-4 w-4" />
-                        <span className='hidden md:inline'>Filters</span>
+                        <span className="hidden md:inline">Filters</span>
+                        {activeFilterCount > 0 && (
+                            <span className="ml-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
+                                {activeFilterCount}
+                            </span>
+                        )}
                     </Button>
                 </PopoverTrigger>
 
-                <PopoverContent className="w-auto px-10 py-6">
-                    <div className="flex flex-col sm:grid sm:grid-cols-2 gap-6">
-                        {/* Sex */}
-                        <FilterGroup
-                            label="Sex"
-                            options={SEX_OPTIONS}
-                            selected={filters.sexes}
-                            onToggle={(val) => toggleFilterItem('sexes', val)}
-                        />
+                <PopoverContent className="w-[320px] sm:w-[480px] p-0 shadow-xl" align="end">
+                    <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/30">
+                        <h3 className="font-semibold text-sm flex items-center gap-2">
+                            <ListFilter className="h-4 w-4" />
+                            Filters
+                        </h3>
+                        {activeFilterCount > 0 && (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={reset}
+                                className="h-8 px-2 text-xs text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                            >
+                                <RotateCcw className="mr-1.5 h-3 w-3" />
+                                Clear All
+                            </Button>
+                        )}
+                    </div>
 
-                        {/* Disease */}
-                        <FilterGroup
-                            label="Disease"
-                            options={DISEASE_OPTIONS}
-                            selected={filters.diseases}
-                            onToggle={(val) => toggleFilterItem('diseases', val)}
-                        />
+                    <ScrollArea className="h-[400px] sm:h-[500px]">
+                        <div className="p-4 space-y-8">
+                            {/* Demographics Group */}
+                            <div className="space-y-4">
+                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
+                                    Demographics
+                                </h4>
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6">
+                                    <FilterSection
+                                        label="Sex"
+                                        options={SEX_OPTIONS.map((opt) => ({ label: opt, value: opt }))}
+                                        selected={filters.sexes}
+                                        onToggle={(val) => toggleFilterItem('sexes', val)}
+                                        onClear={() => setFilter('sexes', [])}
+                                    />
+                                    <FilterSection
+                                        label="Age Range"
+                                        type="radio"
+                                        options={AGE_OPTIONS}
+                                        selected={filters.age}
+                                        onSelect={(val) => setFilter('age', val)}
+                                        onClear={() => setFilter('age', null)}
+                                    />
+                                </div>
+                            </div>
 
-                        {/* Status */}
-                        <FilterGroup
-                            label="Status"
-                            options={HEALTH_STATUS_OPTIONS}
-                            selected={filters.statuses}
-                            onToggle={(val) => toggleFilterItem('statuses', val)}
-                        />
+                            <div className="h-px bg-border/50 mx-1" />
 
-                        {/* Ration Card */}
-                        <FilterGroup
-                            label="Ration Card"
-                            options={RATION_COLORS_OPTIONS}
-                            selected={filters.rationColors}
-                            onToggle={(val) => toggleFilterItem('rationColors', val)}
-                        />
+                            {/* Medical Group */}
+                            <div className="space-y-4">
+                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
+                                    Medical
+                                </h4>
+                                <FilterSection
+                                    label="Disease"
+                                    options={DISEASE_OPTIONS.map((opt) => ({ label: opt, value: opt }))}
+                                    selected={filters.diseases}
+                                    onToggle={(val) => toggleFilterItem('diseases', val)}
+                                    onClear={() => setFilter('diseases', [])}
+                                    scrollable
+                                />
+                            </div>
+
+                            <div className="h-px bg-border/50 mx-1" />
+
+                            {/* Status Group */}
+                            <div className="space-y-4">
+                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
+                                    Patient Status
+                                </h4>
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6">
+                                    <FilterSection
+                                        label="Status"
+                                        options={HEALTH_STATUS_OPTIONS.map((opt) => ({ label: opt, value: opt }))}
+                                        selected={filters.statuses}
+                                        onToggle={(val) => toggleFilterItem('statuses', val)}
+                                        onClear={() => setFilter('statuses', [])}
+                                    />
+                                    <div className="space-y-6">
+                                        <FilterSection
+                                            label="Assignment"
+                                            type="radio"
+                                            options={ASSIGNED_OPTIONS}
+                                            selected={filters.assigned}
+                                            onSelect={(val) => setFilter('assigned', val as 'assigned' | 'unassigned' | '')}
+                                            onClear={() => setFilter('assigned', '')}
+                                        />
+                                        <FilterSection
+                                            label="Transfer"
+                                            type="radio"
+                                            options={TRANSFER_OPTIONS}
+                                            selected={filters.transfer}
+                                            onSelect={(val) => setFilter('transfer', val as 'transferred' | 'not_transferred' | '')}
+                                            onClear={() => setFilter('transfer', '')}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="h-px bg-border/50 mx-1" />
+
+                            {/* Government Group */}
+                            <div className="space-y-4 pb-2">
+                                <h4 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground/70 px-1">
+                                    Government
+                                </h4>
+                                <FilterSection
+                                    label="Ration Card"
+                                    options={RATION_COLORS_OPTIONS.map((opt) => ({ label: opt, value: opt }))}
+                                    selected={filters.rationColors}
+                                    onToggle={(val) => toggleFilterItem('rationColors', val)}
+                                    onClear={() => setFilter('rationColors', [])}
+                                />
+                            </div>
+                        </div>
+                    </ScrollArea>
+                    <div className="p-3 border-t bg-muted/10 flex justify-end">
+                        <PopoverTrigger asChild>
+                            <Button size="sm" className="h-8 px-4 text-xs font-medium">
+                                Apply Filters
+                            </Button>
+                        </PopoverTrigger>
                     </div>
                 </PopoverContent>
             </Popover>
@@ -80,34 +191,104 @@ export function PatientFilter() {
     )
 }
 
-function FilterGroup({
+interface FilterOption {
+    label: string
+    value: string
+}
+
+function FilterSection({
     label,
     options,
     selected,
     onToggle,
+    onSelect,
+    onClear,
+    type = 'checkbox',
+    scrollable = false,
 }: {
     label: string
-    options: string[]
-    selected: string[]
-    onToggle: (val: string) => void
+    options: FilterOption[]
+    selected: string | string[] | null
+    onToggle?: (val: string) => void
+    onSelect?: (val: string) => void
+    onClear: () => void
+    type?: 'checkbox' | 'radio'
+    scrollable?: boolean
 }) {
-    return (
-        <div className="min-w-[150px]">
-            <Label className="text-sm font-medium">{label}</Label>
-            <div className="mt-2 space-y-1">
-                {options.map((option) => (
-                    <div key={option} className="flex items-center space-x-2">
+    const activeCount = Array.isArray(selected) ? selected.length : selected ? 1 : 0
+
+    const content = (
+        <div className="mt-2.5 space-y-2">
+            {type === 'checkbox' ? (
+                options.map((option) => (
+                    <div key={option.value} className="flex items-center space-x-2.5 group">
                         <Checkbox
-                            id={`${label}-${option}`}
-                            checked={selected.includes(option)}
-                            onCheckedChange={() => onToggle(option)}
+                            id={`${label}-${option.value}`}
+                            checked={Array.isArray(selected) && selected.includes(option.value)}
+                            onCheckedChange={() => onToggle?.(option.value)}
+                            className="transition-transform group-hover:scale-105"
                         />
-                        <Label htmlFor={`${label}-${option}`} className="capitalize">
-                            {option}
+                        <Label
+                            htmlFor={`${label}-${option.value}`}
+                            className={cn(
+                                "text-xs font-medium capitalize cursor-pointer flex-1 transition-colors",
+                                Array.isArray(selected) && selected.includes(option.value) ? "text-primary" : "text-muted-foreground group-hover:text-foreground"
+                            )}
+                        >
+                            {option.label}
                         </Label>
                     </div>
-                ))}
+                ))
+            ) : (
+                <RadioGroup value={(selected as string) || ''} onValueChange={onSelect} className="gap-2">
+                    {options.map((option) => (
+                        <div key={option.value} className="flex items-center space-x-2.5 group">
+                            <RadioGroupItem value={option.value} id={`${label}-${option.value}`} />
+                            <Label
+                                htmlFor={`${label}-${option.value}`}
+                                className={cn(
+                                    "text-xs font-medium capitalize cursor-pointer flex-1 transition-colors",
+                                    selected === option.value ? "text-primary" : "text-muted-foreground group-hover:text-foreground"
+                                )}
+                            >
+                                {option.label}
+                            </Label>
+                        </div>
+                    ))}
+                </RadioGroup>
+            )}
+        </div>
+    )
+
+    return (
+        <div className="flex flex-col min-w-[140px]">
+            <div className="flex items-center justify-between mb-1">
+                <div className="flex items-center gap-2">
+                    <span className="text-[13px] font-semibold text-foreground/90">{label}</span>
+                    {activeCount > 0 && (
+                        <span className="inline-flex items-center justify-center h-4 px-1.5 rounded-full bg-primary/10 text-primary text-[10px] font-bold">
+                            {activeCount}
+                        </span>
+                    )}
+                </div>
+                {activeCount > 0 && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={onClear}
+                        className="h-5 w-5 p-0 text-muted-foreground/50 hover:text-destructive hover:bg-transparent"
+                    >
+                        <X className="h-3.5 w-3.5" />
+                    </Button>
+                )}
             </div>
+            {scrollable ? (
+                <ScrollArea className="h-[140px] mt-2 pr-3 -mr-1">
+                    {content}
+                </ScrollArea>
+            ) : (
+                content
+            )}
         </div>
     )
 }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
## Summary
Closes #141 
This PR refactors the `PatientFilter` component to improve the overall UX, structure, and scalability of the filtering system. The main change is moving from a Popover-based layout to a Sheet (side drawer) layout, which provides a more stable and scalable experience for the dashboard.

## Changes Made

* Switched the filter UI from a Popover to a Sheet layout to avoid positioning/jitter issues and improve usability
* Grouped filters into logical sections:

  * Demographics
  * Medical
  * Care Status
  * Government
* Added active filter count indicators globally and per section
* Added:

  * Global “Clear All” functionality
  * Individual section reset buttons
* Exposed existing store-supported filters that were previously hidden:

  * Age Range
  * Assignment Status
  * Transfer Status
* Improved responsiveness and spacing for both desktop and mobile layouts
* Kept the implementation aligned with the existing shadcn/Tailwind design patterns

## Technical Notes

* Added `components/ui/sheet.tsx` using the standard shadcn component setup
* Preserved the existing `usePatientFilterStore` logic and filtering behavior
* No backend or business logic changes were made
* Verified compatibility with the current Webpack/PWA setup
* Passed local lint and build checks successfully

## Screenshot

<img width="1829" height="901" alt="Screenshot 2026-05-11 233435" src="https://github.com/user-attachments/assets/4c21f477-82a8-4b3c-9527-0b1850b8c285" />


## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my own code
* [x] The UI is responsive and accessible
* [x] Verified build and lint checks pass locally
