### PR TITLE
feat(table): add client-side sorting with arrows and tooltips to patient table

### DIFF
--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -91,7 +91,7 @@ export function GenericTable({
     } = useSearch<ActiveDataType>(baseData, searchFields)
 
      // ✅ Apply sorting after search
-const { sorting, toggle, sortedData,setSorting } = useSorting(searchedData)
+const { sorting, toggle, sortedData } = useSorting(searchedData)
 
     // ✅ Use searchedData for pagination
     const dataToPaginate = useMemo(() => sortedData, [sortedData])
@@ -112,12 +112,7 @@ const { sorting, toggle, sortedData,setSorting } = useSorting(searchedData)
     // Reset to page 1 whenever sorting changes
      useEffect(() => {
     setCurrentPage(1)
-}, [sorting])
-
-    // useEffect to reset sort when activeTab changes 
-  useEffect(() => {
-  setSorting([{ id: 'name', desc: false }])
-}, [activeTab])
+  },  [sorting,setCurrentPage])
 
 
     const handleRowAction = useCallback(

--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -23,6 +23,15 @@ import { useTableStore } from '@/store'
 import { useResponsiveRows } from '@/hooks/table/useResponsiveRows'
 import { TabDataMap, RowDataBase, ModalType } from '@/types/table/types'
 import { GenericMobileRow } from './GenericMobileRow'
+import { ArrowUp, ArrowDown, ArrowUpDown } from 'lucide-react'
+import {
+Tooltip,
+TooltipContent,
+TooltipProvider,
+TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useSorting, SORTABLE_KEYS } from '@/hooks/table/useSorting'
+
 
 export function GenericTable({
     headers,
@@ -81,8 +90,11 @@ export function GenericTable({
         setSearchTerm,
     } = useSearch<ActiveDataType>(baseData, searchFields)
 
+     // ✅ Apply sorting after search
+const { sorting, toggle, sortedData,setSorting } = useSorting(searchedData)
+
     // ✅ Use searchedData for pagination
-    const dataToPaginate = useMemo(() => searchedData, [searchedData])
+    const dataToPaginate = useMemo(() => sortedData, [sortedData])
 
     const tableData = usePagination<(typeof dataToPaginate)[number]>(dataToPaginate, rowsPerPage)
 
@@ -96,6 +108,17 @@ export function GenericTable({
     useEffect(() => {
         setCurrentPage(1)
     }, [filteredPatients.length, setCurrentPage])
+
+    // Reset to page 1 whenever sorting changes
+     useEffect(() => {
+    setCurrentPage(1)
+}, [sorting])
+
+    // useEffect to reset sort when activeTab changes 
+  useEffect(() => {
+  setSorting([{ id: 'name', desc: false }])
+}, [activeTab])
+
 
     const handleRowAction = useCallback(
         (row: RowDataBase, action: ModalType) => {
@@ -131,16 +154,57 @@ export function GenericTable({
                         <TableHead className="border-border w-12 border-r text-center">
                             S/NO
                         </TableHead>
-                        {headers.map((header, id) => (
-                            <TableHead className="border-border w-12 border-r text-center" key={id}>
-                                {header.name}
-                            </TableHead>
-                        ))}
-                        <TableHead className="border-border w-12 border-r text-center">
-                            Actions
-                        </TableHead>
-                    </TableRow>
-                </TableHeader>
+                        {headers.map((header, id) => {
+                   const isSortable = SORTABLE_KEYS.includes(header.key)
+                   const isActive = sorting[0]?.id === header.key
+                   const direction = sorting[0]?.desc ? 'desc' : 'asc'
+
+             return (
+                  <TableHead
+             className="border-border w-12 border-r text-center"
+                key={id}
+                >
+               {isSortable ? (
+               <TooltipProvider>
+               <Tooltip>
+              <TooltipTrigger asChild>
+              <button
+              onClick={() => toggle(header.key)}
+            className="flex items-center justify-center gap-1 w-full font-medium hover:text-foreground"
+            >
+           {header.name}
+          {isActive && direction === 'asc' && (
+          <ArrowUp className="w-3 h-3" />
+          )}
+          {isActive && direction === 'desc' && (
+         <ArrowDown className="w-3 h-3" />
+          )}
+        {!isActive && (
+       <ArrowUpDown className="w-3 h-3 opacity-40" />
+        )}
+       </button>
+      </TooltipTrigger>
+      <TooltipContent>
+      {!isActive 
+       ? 'Sort ascending'           // not sorted yet → first click = asc
+       : direction === 'asc' 
+       ? 'Sort descending'        // currently asc → next click = desc
+       : 'Sort ascending'         // currently desc → next click = asc
+      }
+       </TooltipContent>
+       </Tooltip>
+       </TooltipProvider>
+        ) : (
+       header.name
+       )}
+      </TableHead>
+      )                          
+     })}
+              <TableHead className="border-border w-12 border-r text-center">
+                  Actions
+                  </TableHead>
+                  </TableRow>
+                  </TableHeader>
 
                 <TableBody>
                     {paginatedData.length > 0 ? (

--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -24,14 +24,8 @@ import { useResponsiveRows } from '@/hooks/table/useResponsiveRows'
 import { TabDataMap, RowDataBase, ModalType } from '@/types/table/types'
 import { GenericMobileRow } from './GenericMobileRow'
 import { ArrowUp, ArrowDown, ArrowUpDown } from 'lucide-react'
-import {
-Tooltip,
-TooltipContent,
-TooltipProvider,
-TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useSorting, SORTABLE_KEYS } from '@/hooks/table/useSorting'
-
 
 export function GenericTable({
     headers,
@@ -76,7 +70,7 @@ export function GenericTable({
     const searchFields = SEARCH_FIELDS[activeTab]
 
     const isPatientTab = activeTab === 'patients'
-    const isHospitalTab = activeTab =='hospitals'
+    const isHospitalTab = activeTab == 'hospitals'
     const patients = (data as Patient[]) ?? []
     const filteredPatients = useFilteredPatients(isPatientTab ? patients : [])
 
@@ -90,8 +84,8 @@ export function GenericTable({
         setSearchTerm,
     } = useSearch<ActiveDataType>(baseData, searchFields)
 
-     // ✅ Apply sorting after search
-const { sorting, toggle, sortedData } = useSorting(searchedData)
+    // ✅ Apply sorting after search
+    const { sorting, toggle, sortedData } = useSorting(searchedData)
 
     // ✅ Use searchedData for pagination
     const dataToPaginate = useMemo(() => sortedData, [sortedData])
@@ -102,7 +96,8 @@ const { sorting, toggle, sortedData } = useSorting(searchedData)
 
     const tableStats = useStats({
         TableData: searchedData ?? [],
-        isPatientTab, isHospitalTab
+        isPatientTab,
+        isHospitalTab,
     })
 
     useEffect(() => {
@@ -110,10 +105,9 @@ const { sorting, toggle, sortedData } = useSorting(searchedData)
     }, [filteredPatients.length, setCurrentPage])
 
     // Reset to page 1 whenever sorting changes
-     useEffect(() => {
-    setCurrentPage(1)
-  },  [sorting,setCurrentPage])
-
+    useEffect(() => {
+        setCurrentPage(1)
+    }, [sorting, setCurrentPage])
 
     const handleRowAction = useCallback(
         (row: RowDataBase, action: ModalType) => {
@@ -150,56 +144,57 @@ const { sorting, toggle, sortedData } = useSorting(searchedData)
                             S/NO
                         </TableHead>
                         {headers.map((header, id) => {
-                   const isSortable = SORTABLE_KEYS.includes(header.key)
-                   const isActive = sorting[0]?.id === header.key
-                   const direction = sorting[0]?.desc ? 'desc' : 'asc'
+                            const isSortable = SORTABLE_KEYS.includes(header.key)
+                            const isActive = sorting[0]?.id === header.key
+                            const direction = sorting[0]?.desc ? 'desc' : 'asc'
 
-             return (
-                  <TableHead
-             className="border-border w-12 border-r text-center"
-                key={id}
-                >
-               {isSortable ? (
-               <TooltipProvider>
-               <Tooltip>
-              <TooltipTrigger asChild>
-              <button
-              onClick={() => toggle(header.key)}
-            className="flex items-center justify-center gap-1 w-full font-medium hover:text-foreground"
-            >
-           {header.name}
-          {isActive && direction === 'asc' && (
-          <ArrowUp className="w-3 h-3" />
-          )}
-          {isActive && direction === 'desc' && (
-         <ArrowDown className="w-3 h-3" />
-          )}
-        {!isActive && (
-       <ArrowUpDown className="w-3 h-3 opacity-40" />
-        )}
-       </button>
-      </TooltipTrigger>
-      <TooltipContent>
-      {!isActive 
-       ? 'Sort ascending'           // not sorted yet → first click = asc
-       : direction === 'asc' 
-       ? 'Sort descending'        // currently asc → next click = desc
-       : 'Sort ascending'         // currently desc → next click = asc
-      }
-       </TooltipContent>
-       </Tooltip>
-       </TooltipProvider>
-        ) : (
-       header.name
-       )}
-      </TableHead>
-      )                          
-     })}
-              <TableHead className="border-border w-12 border-r text-center">
-                  Actions
-                  </TableHead>
-                  </TableRow>
-                  </TableHeader>
+                            return (
+                                <TableHead
+                                    className="border-border w-12 border-r text-center"
+                                    key={id}
+                                >
+                                    {isSortable ? (
+                                        <TooltipProvider>
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <button
+                                                        onClick={() => toggle(header.key)}
+                                                        className="hover:text-foreground flex w-full items-center justify-center gap-1 font-medium"
+                                                    >
+                                                        {header.name}
+                                                        {isActive && direction === 'asc' && (
+                                                            <ArrowUp className="h-3 w-3" />
+                                                        )}
+                                                        {isActive && direction === 'desc' && (
+                                                            <ArrowDown className="h-3 w-3" />
+                                                        )}
+                                                        {!isActive && (
+                                                            <ArrowUpDown className="h-3 w-3 opacity-40" />
+                                                        )}
+                                                    </button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    {
+                                                        !isActive
+                                                            ? 'Sort ascending' // not sorted yet → first click = asc
+                                                            : direction === 'asc'
+                                                              ? 'Sort descending' // currently asc → next click = desc
+                                                              : 'Sort ascending' // currently desc → next click = asc
+                                                    }
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        </TooltipProvider>
+                                    ) : (
+                                        header.name
+                                    )}
+                                </TableHead>
+                            )
+                        })}
+                        <TableHead className="border-border w-12 border-r text-center">
+                            Actions
+                        </TableHead>
+                    </TableRow>
+                </TableHeader>
 
                 <TableBody>
                     {paginatedData.length > 0 ? (

--- a/hooks/table/useSorting.ts
+++ b/hooks/table/useSorting.ts
@@ -2,48 +2,49 @@ import { useState, useMemo } from 'react'
 import { SortingState } from '@tanstack/react-table'
 
 export const SORTABLE_KEYS = ['name', 'dob']
+const STORAGE_KEY = 'patient-table-sorting'
 
 export function useSorting<T extends Record<string, any>>(data: T[]) {
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: 'name', desc: false },
-  ])
-
-  const sortedData = useMemo(() => {
-    if (!data.length) return []
-
-    return [...data].sort((a, b) => {
-      const sortKey = sorting[0]?.id
-      const desc = sorting[0]?.desc ?? false
-
-      if (!sortKey) return 0
-
-      const aVal = a[sortKey] ?? ''
-      const bVal = b[sortKey] ?? ''
-
-      if (sortKey === 'dob') {
-        const dateA = new Date(aVal as string).getTime()
-        const dateB = new Date(bVal as string).getTime()
-        const cmp = dateA < dateB ? -1 : dateA > dateB ? 1 : 0
-        // Flipped because older dob = higher age, so direction is visually inverted
-        return desc ? cmp : -cmp
-      }
-
-      const cmp = String(aVal).localeCompare(String(bVal), undefined, { sensitivity: 'base' })
-      return desc ? -cmp : cmp
-    })
-  }, [data, sorting])
+  const [sorting, setSorting] = useState<SortingState>(() => {
+    if (typeof window === 'undefined') return [{ id: 'name', desc: false }]
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (saved) return JSON.parse(saved)
+    } catch {
+      // ignore
+    }
+    return [{ id: 'name', desc: false }]
+  })
 
   const toggle = (columnId: string) => {
     setSorting((prev) => {
       const existing = prev.find((s) => s.id === columnId)
-      if (existing) {
-        // Same column — toggle direction
-        return [{ id: columnId, desc: !existing.desc }]
-      }
-      // New column — start ascending
-      return [{ id: columnId, desc: false }]
+      const newSorting: SortingState = existing
+        ? [{ id: columnId, desc: !existing.desc }]
+        : [{ id: columnId, desc: false }]
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newSorting))
+      return newSorting
     })
   }
+
+  const sortedData = useMemo(() => {
+     if (!data.length) return []
+    return [...data].sort((a, b) => {
+      const sortKey = sorting[0]?.id
+      const desc = sorting[0]?.desc ?? false
+      if (!sortKey) return 0
+      const aVal = a[sortKey] ?? ''
+      const bVal = b[sortKey] ?? ''
+      if (sortKey === 'dob') {
+        const dateA = new Date(aVal as string).getTime()
+        const dateB = new Date(bVal as string).getTime()
+        const cmp = dateA < dateB ? -1 : dateA > dateB ? 1 : 0
+        return desc ? cmp : -cmp
+      }
+      const cmp = String(aVal).localeCompare(String(bVal), undefined, { sensitivity: 'base' })
+      return desc ? -cmp : cmp
+    })
+  }, [data, sorting])
 
   return {
     sorting,

--- a/hooks/table/useSorting.ts
+++ b/hooks/table/useSorting.ts
@@ -4,52 +4,52 @@ import { SortingState } from '@tanstack/react-table'
 export const SORTABLE_KEYS = ['name', 'dob']
 const STORAGE_KEY = 'patient-table-sorting'
 
-export function useSorting<T extends Record<string, any>>(data: T[]) {
-  const [sorting, setSorting] = useState<SortingState>(() => {
-    if (typeof window === 'undefined') return [{ id: 'name', desc: false }]
-    try {
-      const saved = localStorage.getItem(STORAGE_KEY)
-      if (saved) return JSON.parse(saved)
-    } catch {
-      // ignore
+export function useSorting<T extends Record<string, unknown>>(data: T[]) {
+    const [sorting, setSorting] = useState<SortingState>(() => {
+        if (typeof window === 'undefined') return [{ id: 'name', desc: false }]
+        try {
+            const saved = localStorage.getItem(STORAGE_KEY)
+            if (saved) return JSON.parse(saved)
+        } catch {
+            // ignore
+        }
+        return [{ id: 'name', desc: false }]
+    })
+
+    const toggle = (columnId: string) => {
+        setSorting((prev) => {
+            const existing = prev.find((s) => s.id === columnId)
+            const newSorting: SortingState = existing
+                ? [{ id: columnId, desc: !existing.desc }]
+                : [{ id: columnId, desc: false }]
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(newSorting))
+            return newSorting
+        })
     }
-    return [{ id: 'name', desc: false }]
-  })
 
-  const toggle = (columnId: string) => {
-    setSorting((prev) => {
-      const existing = prev.find((s) => s.id === columnId)
-      const newSorting: SortingState = existing
-        ? [{ id: columnId, desc: !existing.desc }]
-        : [{ id: columnId, desc: false }]
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(newSorting))
-      return newSorting
-    })
-  }
+    const sortedData = useMemo(() => {
+        if (!data.length) return []
+        return [...data].sort((a, b) => {
+            const sortKey = sorting[0]?.id
+            const desc = sorting[0]?.desc ?? false
+            if (!sortKey) return 0
+            const aVal = (a[sortKey] ?? '') as string
+            const bVal = (b[sortKey] ?? '') as string
+            if (sortKey === 'dob') {
+                const dateA = new Date(aVal as string).getTime()
+                const dateB = new Date(bVal as string).getTime()
+                const cmp = dateA < dateB ? -1 : dateA > dateB ? 1 : 0
+                return desc ? cmp : -cmp
+            }
+            const cmp = String(aVal).localeCompare(String(bVal), undefined, { sensitivity: 'base' })
+            return desc ? -cmp : cmp
+        })
+    }, [data, sorting])
 
-  const sortedData = useMemo(() => {
-     if (!data.length) return []
-    return [...data].sort((a, b) => {
-      const sortKey = sorting[0]?.id
-      const desc = sorting[0]?.desc ?? false
-      if (!sortKey) return 0
-      const aVal = a[sortKey] ?? ''
-      const bVal = b[sortKey] ?? ''
-      if (sortKey === 'dob') {
-        const dateA = new Date(aVal as string).getTime()
-        const dateB = new Date(bVal as string).getTime()
-        const cmp = dateA < dateB ? -1 : dateA > dateB ? 1 : 0
-        return desc ? cmp : -cmp
-      }
-      const cmp = String(aVal).localeCompare(String(bVal), undefined, { sensitivity: 'base' })
-      return desc ? -cmp : cmp
-    })
-  }, [data, sorting])
-
-  return {
-    sorting,
-    setSorting,
-    toggle,
-    sortedData,
-  }
+    return {
+        sorting,
+        setSorting,
+        toggle,
+        sortedData,
+    }
 }

--- a/hooks/table/useSorting.ts
+++ b/hooks/table/useSorting.ts
@@ -1,0 +1,54 @@
+import { useState, useMemo } from 'react'
+import { SortingState } from '@tanstack/react-table'
+
+export const SORTABLE_KEYS = ['name', 'dob']
+
+export function useSorting<T extends Record<string, any>>(data: T[]) {
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'name', desc: false },
+  ])
+
+  const sortedData = useMemo(() => {
+    if (!data.length) return []
+
+    return [...data].sort((a, b) => {
+      const sortKey = sorting[0]?.id
+      const desc = sorting[0]?.desc ?? false
+
+      if (!sortKey) return 0
+
+      const aVal = a[sortKey] ?? ''
+      const bVal = b[sortKey] ?? ''
+
+      if (sortKey === 'dob') {
+        const dateA = new Date(aVal as string).getTime()
+        const dateB = new Date(bVal as string).getTime()
+        const cmp = dateA < dateB ? -1 : dateA > dateB ? 1 : 0
+        // Flipped because older dob = higher age, so direction is visually inverted
+        return desc ? cmp : -cmp
+      }
+
+      const cmp = String(aVal).localeCompare(String(bVal), undefined, { sensitivity: 'base' })
+      return desc ? -cmp : cmp
+    })
+  }, [data, sorting])
+
+  const toggle = (columnId: string) => {
+    setSorting((prev) => {
+      const existing = prev.find((s) => s.id === columnId)
+      if (existing) {
+        // Same column — toggle direction
+        return [{ id: columnId, desc: !existing.desc }]
+      }
+      // New column — start ascending
+      return [{ id: columnId, desc: false }]
+    })
+  }
+
+  return {
+    sorting,
+    setSorting,
+    toggle,
+    sortedData,
+  }
+}


### PR DESCRIPTION
Closes #101

## Summary
Added client-side sorting to the patient table for the `name` and `dob` (Age) columns.

- Created a new `useSorting` hook that uses TanStack React Table internally for sorting state management and returns plain sorted data to keep the existing `GenericRow` and `GenericMobileRow` components untouched
- Sortable column headers (`Patient Name`, `Age`) now show arrow indicators (↑ ascending, ↓ descending, ↕ unsorted)
- Hovering over a sortable header shows a tooltip: "Sort descending" when ascending, "Sort ascending" when descending
- Default sort is by Patient Name ascending on load
- Sort resets to page 1 when changed
- All sorting is client-side — no extra Firestore calls

## Type of change
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test
1. Navigate to any patient table (Doctor Dashboard or Admin Dashboard → Patients tab)
2. Click **Patient Name** header — table sorts A→Z, arrow shows ↑
3. Click **Patient Name** again — sorts Z→A, arrow shows ↓
4. Click **Age** header — sorts youngest→oldest, arrow shows ↑
5. Click **Age** again — sorts oldest→youngest, arrow shows ↓
6. Hover over an active sorted column — tooltip shows correct next action
7. Navigate to page 2, click sort — should jump back to page 1
8. Verify Phone, Sex, Status, Diseases columns are **not** sortable (no arrows)


## Checklist
- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots:
First it begins with sort ascending :
<img width="1841" height="947" alt="Screenshot 2026-05-13 230331" src="https://github.com/user-attachments/assets/c4340a74-cc47-4efd-8225-cc21e963a82b" />
After sorting(ascending)
<img width="1844" height="953" alt="Screenshot 2026-05-13 230354" src="https://github.com/user-attachments/assets/36abd276-b204-4308-a81e-a5536baba7e0" />
Then:
<img width="1846" height="907" alt="image" src="https://github.com/user-attachments/assets/205ab38f-00c6-4151-8678-f7ded29d217a" />
After sorting(descending):
<img width="1845" height="902" alt="image" src="https://github.com/user-attachments/assets/6e942017-0c8e-47a6-8415-92712b2798e7" />
Same order follows with patients name.