### PR TITLE
test: cover LoginPage behavior

### DIFF
--- a/__tests__/unit/login/LoginPage.test.tsx
+++ b/__tests__/unit/login/LoginPage.test.tsx
@@ -1,8 +1,11 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import LoginPage from '@/app/login/page'
 import { useAuth } from '@/contexts/AuthContext'
 import { useRouter } from 'next/navigation'
+import { signInWithEmailAndPassword } from 'firebase/auth'
+import { toast } from 'sonner'
+import userEvent from '@testing-library/user-event'
 
 // Mock dependencies
 vi.mock('firebase/auth', () => {
@@ -28,6 +31,8 @@ vi.mock('@/contexts/AuthContext', () => ({
 
 describe('LoginPage (Unit)', () => {
     const push = vi.fn()
+    const signInMock = signInWithEmailAndPassword as unknown as ReturnType<typeof vi.fn>
+    const toastErrorMock = toast.error as unknown as ReturnType<typeof vi.fn>
 
     beforeEach(() => {
         ;(useRouter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ push })
@@ -57,5 +62,91 @@ describe('LoginPage (Unit)', () => {
         expect(passwordInput).toHaveAttribute('type', 'password')
         fireEvent.click(toggleButton)
         expect(passwordInput).toHaveAttribute('type', 'text')
+    })
+
+    it('submits valid credentials with the normalized email and password', async () => {
+        const user = userEvent.setup()
+        signInMock.mockResolvedValueOnce({})
+
+        render(<LoginPage />)
+
+        await user.type(screen.getByPlaceholderText(/Email/i), 'Doctor@Example.com')
+        await user.type(screen.getByPlaceholderText(/Password/i), 'secret123')
+        await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+        await waitFor(() => {
+            expect(signInMock).toHaveBeenCalledWith(
+                expect.anything(),
+                'doctor@example.com',
+                'secret123'
+            )
+        })
+    })
+
+    it('does not submit when required fields are empty', async () => {
+        const user = userEvent.setup()
+
+        render(<LoginPage />)
+
+        await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+        expect(await screen.findByText(/Email is required/i)).toBeInTheDocument()
+        expect(await screen.findByText(/Password is required/i)).toBeInTheDocument()
+        expect(signInMock).not.toHaveBeenCalled()
+    })
+
+    it('shows an error toast when login fails', async () => {
+        const user = userEvent.setup()
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        signInMock.mockRejectedValueOnce(new Error('Network unavailable'))
+
+        render(<LoginPage />)
+
+        await user.type(screen.getByPlaceholderText(/Email/i), 'doctor@example.com')
+        await user.type(screen.getByPlaceholderText(/Password/i), 'secret123')
+        await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+        await waitFor(() => {
+            expect(toastErrorMock).toHaveBeenCalledWith(
+                'An unexpected error occurred. Please try again.'
+            )
+        })
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Login error:', expect.any(Error))
+        consoleErrorSpy.mockRestore()
+    })
+
+    it('clears the form after a successful login request', async () => {
+        const user = userEvent.setup()
+        signInMock.mockResolvedValueOnce({})
+
+        render(<LoginPage />)
+
+        const emailInput = screen.getByPlaceholderText(/Email/i)
+        const passwordInput = screen.getByPlaceholderText(/Password/i)
+
+        await user.type(emailInput, 'doctor@example.com')
+        await user.type(passwordInput, 'secret123')
+        await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+        await waitFor(() => {
+            expect(signInMock).toHaveBeenCalledTimes(1)
+        })
+        await waitFor(() => {
+            expect(emailInput).toHaveValue('')
+            expect(passwordInput).toHaveValue('')
+        })
+        expect(toastErrorMock).not.toHaveBeenCalled()
+    })
+
+    it('redirects an authenticated user to the route for their role', () => {
+        ;(useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            user: { uid: 'doctor-1' },
+            role: 'doctor',
+            isLoadingAuth: false,
+        })
+
+        render(<LoginPage />)
+
+        expect(push).toHaveBeenCalledWith('/PuduCan/doctor')
     })
 })


### PR DESCRIPTION
## Summary
- Add LoginPage unit coverage for valid credential submission and normalized email handling.
- Verify empty submissions do not call Firebase sign-in.
- Cover failed login toast behavior, successful form reset, and role-based redirect behavior using existing mocks.

## Linked issue
Fixes #31

## Type of change
- [x] Tests

## Testing
- `npm test -- __tests__\unit\login\LoginPage.test.tsx --run`
- `npm test -- --run`
- `./node_modules/.bin/eslint.cmd __tests__\unit\login\LoginPage.test.tsx`

Note: repo-wide `npm run lint` currently reports unrelated existing lint errors outside this change. The changed LoginPage test file passes direct ESLint.