### PR TITLE
feat: implement bulk delete functionality with selection and confirmmation dialog

### DIFF
--- a/__tests__/unit/bulkAssign.test.tsx
+++ b/__tests__/unit/bulkAssign.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import {  render, screen, waitFor } from "@testing-library/react";
+import { it, describe, expect, vi, beforeEach } from "vitest";
+import {  getDocs, updateDoc } from "firebase/firestore";
+import { BulkAssignDialog } from "@/components/dialogs/BulkAssignDialog";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+
+// firebase functions are mocked to avoid actual database operations during tests
+vi.mock('@/firebase', ()=>({ db: {}}))
+vi.mock("firebase/firestore", () => ({
+    getDocs: vi.fn(),
+    updateDoc: vi.fn(),
+    collection: vi.fn(),
+    query: vi.fn(),
+    where: vi.fn(),
+    doc: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn()
+    }
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+    useAuth: () => ({ orgId: 'testOrg' })
+}))
+
+//fake ASHA data for testing
+const mockAshas = [
+    {id: 'asha-1', name: 'Asha 1', email: 'asha1@example.com', phoneNumber: '1234567890'},
+    {id: 'asha-2', name: 'Asha 2', email: 'asha2@example.com', phoneNumber: '0987654321'},
+    {id: 'asha-3', name: 'Asha 3', email: 'asha3@example.com', phoneNumber: '1112223333'}
+]
+
+function wrapper ({children}: {children: React.ReactNode}) {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false
+            }
+        },
+    })
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+//firestore getDocs mock to return fake ASHA data
+const getMockGetDocs = (ashas: typeof mockAshas) => {
+    return {
+        docs: ashas.map(asha => ({
+            id: asha.id,
+            data: () => ({ name: asha.name, email: asha.email, phoneNumber: asha.phoneNumber })
+        }))
+    }
+}
+
+
+// store
+describe('BulkAssignDialog', () => { 
+    beforeEach(() => {
+        vi.clearAllMocks() // reset mocks before each test
+        vi.mocked(getDocs).mockResolvedValue(getMockGetDocs(mockAshas) as any) // mock getDocs to return fake ASHA data
+        vi.mocked(updateDoc).mockResolvedValue(undefined) 
+        
+    })
+
+    it('renders correct patient count in title', async() => {
+        render (
+            <BulkAssignDialog open={true} ids={['p1', 'p2', 'p3']} onClose={vi.fn()}/>, {wrapper} )
+
+        expect(screen.getByText('Assign ASHA to 3 patients')).toBeInTheDocument()
+    })
+     
+    it('render singular label for one patient', async () => {
+        render(<BulkAssignDialog open={true} ids={['p1']} onClose={vi.fn()} />, {wrapper})
+        
+        expect(screen.getByText('Assign ASHA to 1 patient')).toBeInTheDocument()
+    })
+
+    it('render the ASHA list beofre fetching', async() => {
+        render(<BulkAssignDialog open={true} ids={['p1']} onClose={vi.fn()} />, {wrapper})
+        await waitFor( () => {
+            expect(screen.getByText('Asha 1')).toBeInTheDocument()
+            expect(screen.getByText('Asha 2')).toBeInTheDocument()
+            expect(screen.getByText('Asha 3')).toBeInTheDocument()
+        })
+    })
+
+    it('render unassign option when no ASHA is selected', async () => {
+        render(<BulkAssignDialog open={true} ids={['p1']} onClose={vi.fn()} />, {wrapper})
+        await waitFor(() => {
+            expect(screen.getByText('Unassign ASHA')).toBeInTheDocument()
+        })
+    })
+
+    it('does not fetch ASHAs when dialog is closed', async () => {
+        render(<BulkAssignDialog open={false} ids={['p1']} onClose={vi.fn()} />, {wrapper})
+        expect(getDocs).not.toHaveBeenCalled()
+    })
+   
+})
+
+
+

--- a/__tests__/unit/bulkDelete.test.ts
+++ b/__tests__/unit/bulkDelete.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { it, describe, expect, vi, beforeEach } from "vitest";
 import { useBulkSelectionStore } from "@/store/bulk-selection-store";
 

--- a/__tests__/unit/bulkDelete.test.ts
+++ b/__tests__/unit/bulkDelete.test.ts
@@ -1,0 +1,79 @@
+import { act, renderHook, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { it, describe, expect, vi, beforeEach } from "vitest";
+import { useBulkSelectionStore } from "@/store/bulk-selection-store";
+
+
+
+// firebase functions are mocked to avoid actual database operations during tests
+vi.mock('@/firestore', ()=>({ db: {}}))
+vi.mock("firebase/firestore", () => ({
+    deleteDoc: vi.fn(),
+    setDoc: vi.fn(),
+    doc: vi.fn(),
+    serverTimestamp: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn()
+    }
+}))
+
+// store
+describe('useBulkSelectionStore', () => { 
+    beforeEach(() => {
+        useBulkSelectionStore.getState().clearSelection() // reset store before each test
+    })
+
+    it('select a row and check if it is selected', () => {
+        const { result } = renderHook(() => useBulkSelectionStore())
+        act(() => { result.current.toggleRow('row1') })
+        expect(result.current.isSelected('row1')).toBe(true)
+    })
+
+    it('deselect an already selected row', () => {
+        const { result } = renderHook(() => useBulkSelectionStore())
+        act(() =>{ result.current.toggleRow('row1') })
+        act(() =>{ result.current.toggleRow('row1') })
+        expect(result.current.isSelected('row1')).toBe(false)
+    })
+
+    it('does not affect other rows when toggling one row', () => {
+        const { result } = renderHook(() => useBulkSelectionStore())
+        act(() =>{ result.current.toggleRow('row1') })
+        act(() =>{ result.current.toggleRow('row2') })
+        act(() =>{ result.current.toggleRow('row1') }) // deselect row1, row2 should remain selected
+        expect(result.current.isSelected('row1')).toBe(false)
+        expect(result.current.isSelected('row2')).toBe(true)
+    })
+
+    it('selectAll select current page ids' , () => {
+        const { result } = renderHook(() => useBulkSelectionStore())
+        act(() =>{ result.current.selectAll(['row1', 'row2', 'row3']) })
+        expect(result.current.selectionCount()).toBe(3)
+    })
+
+    it('selectAll deselects all rows already selected', () => {
+        const { result } = renderHook(() => useBulkSelectionStore())
+        act(() =>{ result.current.selectAll(['row1', 'row2', 'row3']) })
+        act(() =>{ result.current.selectAll(['row1', 'row2', 'row3']) })
+        expect(result.current.selectionCount()).toBe(0)
+    })
+
+    it('clearSelection clears all selected rows', () => {
+        const { result } = renderHook(() => useBulkSelectionStore())
+        act(() =>{ result.current.selectAll(['row1', 'row2', 'row3']) })
+        act(() =>{ result.current.clearSelection() })
+        expect(result.current.selectionCount()).toBe(0)
+    })
+
+    it('selectedIds returns ids as an array', () => {
+        const { result } = renderHook(() => useBulkSelectionStore())
+        act(() =>{ result.current.selectAll(['row1', 'row2', 'row3']) })
+        expect(result.current.selectedIdsArray()).toEqual(expect.arrayContaining(['row1', 'row2', 'row3']))
+    })
+})
+
+
+

--- a/__tests__/unit/bulkExport.test.tsx
+++ b/__tests__/unit/bulkExport.test.tsx
@@ -1,0 +1,139 @@
+import { renderHook } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { useBulkExport } from "@/hooks/table/useBulkExport"
+
+const mockClick           = vi.fn()
+const mockSetAttribute    = vi.fn()
+const mockCreateObjectURL = vi.fn((_blob: Blob) => 'blob:mock-url')
+const mockRevokeObjectURL = vi.fn()
+
+const fakeLink = {
+    href: '',
+    click: mockClick,
+    setAttribute: mockSetAttribute,
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+
+    global.URL.createObjectURL = mockCreateObjectURL as typeof URL.createObjectURL
+    global.URL.revokeObjectURL = mockRevokeObjectURL
+
+    const original = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'a') {
+            // Create a REAL anchor element satisfies appendChild's Node requirement
+            const realAnchor = original('a')
+            
+            realAnchor.click        = mockClick
+            realAnchor.setAttribute = mockSetAttribute
+            return realAnchor
+        }
+        return original(tag)
+    })
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+
+const headers = [
+    { name: 'Name',  key: 'name'  },
+    { name: 'Phone', key: 'phone' },
+    { name: 'Age',   key: 'age'   },
+]
+
+const allData = [
+    { id: 'asha-1', name: 'Asha 1', phone: '1234', age: 30 },
+    { id: 'asha-2', name: 'Asha 2', phone: '5678', age: 25 },
+    { id: 'asha-3', name: 'Asha 3', phone: '9012', age: 40 },
+]
+
+
+describe('useBulkExport', () => {
+
+    it('does nothing when selectedIds is empty', () => {
+        const { result } = renderHook(() => useBulkExport())
+        result.current.exportSelected([], headers, 'patients', allData as any)
+        expect(mockClick).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when no rows match the selected ids', () => {
+        const { result } = renderHook(() => useBulkExport())
+        result.current.exportSelected(['does-not-exist'], headers, 'patients', allData as any)
+        expect(mockClick).not.toHaveBeenCalled()
+    })
+
+    it('triggers a file download when ids are provided', () => {
+        const { result } = renderHook(() => useBulkExport())
+        result.current.exportSelected(['asha-1'], headers, 'patients', allData as any)
+        expect(mockClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('only exports rows matching selectedIds', () => {
+        const { result } = renderHook(() => useBulkExport())
+
+        let capturedBlob: Blob | undefined
+        mockCreateObjectURL.mockImplementation((_blob: Blob) => {
+            capturedBlob = _blob
+            return 'blob:mock-url'
+        })
+
+        result.current.exportSelected(['asha-1', 'asha-3'], headers, 'patients', allData as any)
+
+        return capturedBlob!.text().then((text) => {
+            expect(text).toContain('Asha 1')
+            expect(text).toContain('Asha 3')
+            expect(text).not.toContain('Asha 2')
+        })
+    })
+
+    it('includes correct CSV header row', () => {
+        const { result } = renderHook(() => useBulkExport())
+
+        let capturedBlob: Blob | undefined
+        mockCreateObjectURL.mockImplementation((_blob: Blob) => {
+            capturedBlob = _blob
+            return 'blob:mock-url'
+        })
+
+        result.current.exportSelected(['asha-1'], headers, 'patients', allData as any)
+
+        return capturedBlob!.text().then((text) => {
+            const firstLine = text.split('\n')[0]
+            expect(firstLine).toBe('Name,Phone,Age')
+        })
+    })
+
+    it('uses correct filename format', () => {
+        const { result } = renderHook(() => useBulkExport())
+        result.current.exportSelected(['asha-1'], headers, 'patients', allData as any)
+
+        const date = new Date().toISOString().split('T')[0]
+        expect(mockSetAttribute).toHaveBeenCalledWith('download', `patients_export_${date}.csv`)
+    })
+
+    it('handles missing field values — uses empty string', () => {
+        const { result } = renderHook(() => useBulkExport())
+        const incompleteData = [{ id: 'asha-1', name: 'Asha 1' }]
+
+        let capturedBlob: Blob | undefined
+        mockCreateObjectURL.mockImplementation((_blob: Blob) => {
+            capturedBlob = _blob
+            return 'blob:mock-url'
+        })
+
+        result.current.exportSelected(['asha-1'], headers, 'patients', incompleteData as any)
+
+        return capturedBlob!.text().then((text) => {
+            expect(text).toContain('"Asha 1",""')
+        })
+    })
+
+    it('revokes the object URL after download', () => {
+        const { result } = renderHook(() => useBulkExport())
+        result.current.exportSelected(['asha-1'], headers, 'patients', allData as any)
+        expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+    })
+})

--- a/components/dialogs/BulkAssignDialog.tsx
+++ b/components/dialogs/BulkAssignDialog.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+} from '@/components/ui/command'
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog'
+import { db } from '@/firebase'
+import { Check, UserCheck, UserPlus, X } from 'lucide-react'
+import { collection, getDocs, query, where, doc, updateDoc } from 'firebase/firestore'
+import {  useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { useAuth } from '@/contexts/AuthContext';
+import  {useMutation, useQueryClient} from '@tanstack/react-query';
+
+type Asha = {
+    id: string
+    email: string
+    name?: string
+    phoneNumber?: string
+}
+
+
+
+type BulkAssignDialogProps = {
+    open: boolean
+    ids: string[] // list of patient IDs to assign/unassign
+    onClose: () => void
+    onAssigned?: (ashaId: string | null) => void
+}
+
+
+export function BulkAssignDialog({
+    open,
+    ids,
+    onClose,
+    onAssigned,
+}: BulkAssignDialogProps){
+    const { orgId } = useAuth() // get orgId from auth
+    const [ashas, setAshas] = useState<Asha[]>([])
+    const [selectedAsha, setSelectedAsha] = useState<Asha | null>(null)
+    const [searchTerm, setSearchTerm] = useState('')
+    const queryClient = useQueryClient()
+
+    const count = ids.length
+
+    // Fetch ASHAs
+    useEffect(() => {
+        if(!open) return // only fetch when dialog opens
+
+        const fetchAshas = async () => {
+            try {
+                let q
+                if (orgId) {
+                    q = query(
+                        collection(db, 'users'),
+                        where('role', '==', 'asha'),
+                        where('orgId', '==', orgId)
+                    )
+                } else {
+                    
+                    q = query(collection(db, 'users'), where('role', '==', 'asha'))
+                }
+
+                const snapshot = await getDocs(q)
+                const ashaList: Asha[] = snapshot.docs.map((doc) => ({
+                    id: doc.id,
+                    ...(doc.data() as Omit<Asha, 'id'>),
+                }))
+                setAshas(ashaList)
+            } catch (error) {
+                console.error('Error fetching ASHAs:', error)
+            }
+        }
+        fetchAshas()
+    }, [open,orgId]) // refetch if orgId changes
+
+    const filteredAshas = ashas
+        .filter(
+            (asha) =>
+                asha.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                asha.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                asha.phoneNumber?.includes(searchTerm)
+        )
+        .slice(0, 10)
+
+
+    const mutation = useMutation({
+        mutationFn: async ()=> {
+            if(!ids.length) throw new Error('No patients selected')
+
+                await Promise.all(
+                    ids.map((id) => {
+                        updateDoc(doc(db, 'patients', id), { assignedAsha: selectedAsha?.id || '' }) // empty string = unassigned
+                    })
+                )
+
+                return ids
+        },
+
+        onSuccess: () =>{
+            queryClient.invalidateQueries({ queryKey:['patients']})
+            toast.success(
+                selectedAsha ? `${count} ${count === 1 ? 'patient' : 'patients'} assigned successfully!` : `${count} 
+                ${count === 1 ? 'patient' : 'patients'} unassigned successfully!`
+            )
+            onAssigned?.(selectedAsha?.id || null)
+            handleClose()
+        }, 
+        onError: (err: any) => { toast.error( err.message || 'Assignment failed. See console for details.'); console.error(err) }
+    })
+
+    function handleClose() {
+        setSelectedAsha(null)
+        setSearchTerm('')
+        onClose()
+    }
+
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Assign ASHA to {count} {count === 1 ? 'patient' : 'patients'}</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    <Command className="rounded-md border shadow-md">
+                        <CommandInput
+                            placeholder="Search ASHA by email, username, or phone..."
+                            onValueChange={(val) => setSearchTerm(val)}
+                        />
+                        <CommandEmpty>No ASHA found.</CommandEmpty>
+                        <CommandGroup>
+                            <CommandItem onSelect={() => setSelectedAsha(null)}>
+                                <div className="flex w-full items-center justify-between">
+                                    <span className="font-medium">Unassign ASHA</span>
+                                </div>
+                            </CommandItem>
+
+                            {filteredAshas.map((asha) => (
+                                <CommandItem key={asha.id} onSelect={() => setSelectedAsha(asha)}>
+                                    <div className="flex w-full items-center justify-between">
+                                        <div>
+                                            {asha.name && (
+                                                <div className="flex space-x-2">
+                                                    <p className="text-muted-foreground text-sm">
+                                                        Name:{' '}
+                                                        <span className="text-foreground">
+                                                            {asha.name}
+                                                        </span>
+                                                    </p>
+                                                    <p className="text-muted-foreground text-sm">
+                                                        Email: {asha.email}
+                                                    </p>
+                                                </div>
+                                            )}
+                                            {asha.phoneNumber && (
+                                                <p className="text-muted-foreground text-sm">
+                                                    PhoneNumber: {asha.phoneNumber}
+                                                </p>
+                                            )}
+                                        </div>
+                                        {selectedAsha?.id === asha.id && (
+                                            <Check className="h-4 w-4 text-blue-600" />
+                                        )}
+                                    </div>
+                                </CommandItem>
+                            ))}
+                        </CommandGroup>
+                    </Command>
+                </div>
+
+                <DialogFooter>
+                    <Button onClick={handleClose} variant="outline" disabled={mutation.isPending}>
+                        Cancel
+                    </Button>
+
+                    <Button onClick={() => mutation.mutate()} disabled={mutation.isPending} >
+                        {
+                            mutation.isPending ? 'Saving ...' : selectedAsha ?
+                            `Confirm ASHA from ${count} ${count === 1 ? 'patient' : 'patients'} ` : 
+                            `Unassigned ASHA from ${count} ${count === 1 ? 'patient' : 'patients'}`
+                        }
+
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/components/dialogs/BulkDeleteDialog.tsx
+++ b/components/dialogs/BulkDeleteDialog.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { db } from '@/firebase'
+import { deleteDoc, doc, setDoc, serverTimestamp } from 'firebase/firestore'
+import { toast } from 'sonner'
+import { count } from 'console'
+
+type Collections = 'patients' | 'hospitals' | 'doctors' | 'nurses' | 'ashas' | 'removedPatients'
+
+type WithIdAndName = { id: string | number; name?: string } & Record<string, any>
+
+type BulkDeleteDialogProps = {
+    open: boolean
+    ids: string[]
+    rowsData?: Record<string, any>[]
+    collectionName: Collections
+    onClose: () => void
+    onDeleted?: (deletedIds: string[]) => void
+}
+
+function labelFromCollection(coll: Collections) {
+    switch (coll) {
+        case 'patients':
+            return 'Patient'
+        case 'hospitals':
+            return 'Hospital'
+        case 'doctors':
+            return 'Doctor'
+        case 'nurses':
+            return 'Nurse'
+        case 'ashas':
+            return 'ASHA'
+        case 'removedPatients':
+            return 'Removed Patient'
+        default:
+            return 'Record'
+    }
+}
+
+function mapToFirestoreCollection(coll: Collections) {
+    if (coll === 'patients') return 'patients'
+    if (coll === 'hospitals') return 'hospitals'
+    if (coll === 'removedPatients') return 'removedPatients'
+    // doctors, nurses, ashas are all in 'users'
+    return 'users'
+}
+
+export default function BulkDeleteDialog({
+    open,
+    ids,
+    rowsData = [],
+    collectionName,
+    onClose,
+    onDeleted,
+}: BulkDeleteDialogProps) {
+    const queryClient = useQueryClient()
+    const [reason, setReason] = useState('')
+
+    const isPatient = collectionName === 'patients'
+    const label = labelFromCollection(collectionName)
+    const count = ids.length
+    const pluralLabel = count === 1 ? label : `${label}s`
+
+    const mutation = useMutation({
+        mutationFn: async () => {
+            if (!ids.length) throw new Error('No records selected for deletion')
+
+            if (isPatient) {
+                // require a reason
+                if (!reason.trim())
+                    throw new Error('Please enter a reason before deleting these patients.')
+                // entries to removedPatients
+               await Promise.all(
+                ids.map(async (id) => {
+                    const patientData = rowsData.find((row: any) => row.id === id) ?? { id}
+
+                    await setDoc(doc(db, 'removedPatients', id), {
+                        ...patientData,
+                        deletionReason: reason,
+                        deletedAt: serverTimestamp(),
+                        removeFrom: 'patients'
+                    })
+                    // 2) delete from patients
+                await deleteDoc(doc(db, 'patients', id))
+                })
+               )
+
+                
+            } else {
+                // direct delete for hospitals/users/removedPatients
+                const coll = mapToFirestoreCollection(collectionName)
+                console.log('coll:', coll)
+                console.log('id:', ids)  
+                await Promise.all(ids.map((id) => deleteDoc(doc(db, coll, id))))
+            }
+
+            return ids
+        },
+        onSuccess: (deletedIds) => {
+            // invalidate the right list
+            if (collectionName === 'patients') {
+                queryClient.invalidateQueries({ queryKey: ['patients'] })
+                queryClient.invalidateQueries({ queryKey: ['removedPatients'] })
+            } else if (collectionName === 'hospitals') {
+                queryClient.invalidateQueries({ queryKey: ['hospitals'] })
+            } else if (collectionName === 'removedPatients') {
+                queryClient.invalidateQueries({ queryKey: ['removedPatients'] })
+            } else {
+                // doctors, nurses, ashas
+                queryClient.invalidateQueries({ queryKey: ['users'] })
+            }
+
+            toast.success(`${count} ${count === 1 ? label : label + 's'} deleted successfully`)
+            onDeleted?.(deletedIds)
+            setReason('')
+            onClose()
+        },
+        onError: (err: any) => {
+            toast.error(err?.message || 'Deletion failed')
+            // keep dialog open so the user can fix reason or retry
+        },
+    })
+
+    const handleConfirm = () => {
+        mutation.mutate()
+    }
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(o) => {
+                if (!o) onClose()
+            }}
+        >
+            <DialogContent>
+                <DialogHeader>
+                        <DialogTitle>Delete {count} {pluralLabel}</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-2">
+                    <p>
+                        Are you sure you want to delete{' '}
+                        <strong className="text-red-600">{count} {pluralLabel.toLowerCase()}</strong>?
+                    </p>
+                    <p className="text-sm text-orange-500">Note: This action cannot be undone.</p>
+                </div>
+
+                {isPatient && (
+                    <div className="mt-3 space-y-4">
+                        <label className="mb-2 block text-sm font-medium">
+                            Reason for deletion
+                        </label>
+                        <Input
+                            value={reason}
+                            onChange={(e) => setReason(e.target.value)}
+                            placeholder="Enter reason..."
+                        />
+                    </div>
+                )}
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={onClose} disabled={mutation.isPending}>
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        onClick={handleConfirm}
+                        disabled={mutation.isPending}
+                    >
+                        {mutation.isPending ? 'Deleting…' : `Delete ${count} ${pluralLabel}`}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/components/dialogs/BulkDeleteDialog.tsx
+++ b/components/dialogs/BulkDeleteDialog.tsx
@@ -14,7 +14,6 @@ import { Input } from '@/components/ui/input'
 import { db } from '@/firebase'
 import { deleteDoc, doc, setDoc, serverTimestamp } from 'firebase/firestore'
 import { toast } from 'sonner'
-import { count } from 'console'
 
 type Collections = 'patients' | 'hospitals' | 'doctors' | 'nurses' | 'ashas' | 'removedPatients'
 
@@ -81,17 +80,15 @@ export default function BulkDeleteDialog({
                 if (!reason.trim())
                     throw new Error('Please enter a reason before deleting these patients.')
                 // entries to removedPatients
-               await Promise.all(
-                ids.map(async (id) => {
+               await Promise.all(ids.map(async (id) => {
                     const patientData = rowsData.find((row: any) => row.id === id) ?? { id}
 
                     await setDoc(doc(db, 'removedPatients', id), {
                         ...patientData,
                         deletionReason: reason,
                         deletedAt: serverTimestamp(),
-                        removeFrom: 'patients'
+                        removedFrom: 'patients'
                     })
-                    // 2) delete from patients
                 await deleteDoc(doc(db, 'patients', id))
                 })
                )

--- a/components/table/BulkActionBar.tsx
+++ b/components/table/BulkActionBar.tsx
@@ -1,0 +1,76 @@
+'use client';
+import { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface BulkAction {
+    key: string;
+    label: string;
+    icon?: ReactNode;
+
+    variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+    onClick: (selectedIds: string[]) => void;
+    hidden?: boolean; // for conditionally hiding actions
+}
+
+interface BulkActionBarProps {
+    selectedCount: number;
+    selectedIds: string[];
+    actions: BulkAction[];
+    onClearSelection: () => void;
+    className?: string;
+}
+
+export function BulkActionBar({
+    selectedCount,
+    selectedIds,
+    actions,
+    onClearSelection,
+    className
+}: BulkActionBarProps) {
+    if (selectedCount === 0) return null; //  if no rows are selected
+    const visibleActions = actions.filter(action => !action.hidden);
+
+    return (
+        <div className={cn(
+        'animate-in slide-in-from-top-2 fade-in duration-200',
+        'flex items-center gap-3 rounded-md border border-border bg-muted/60 px-3 py-2 mb-2',
+        className
+      )}>
+            <span className="flex items-center gap-1.5 text-sm font-medium text-foreground mr-1 shrink-0">
+                <span className="inline-flex items-center justify-center rounded bg-primary text-primary-foreground text-xs font-bold px-1.5 py-0.5 min-w-[1.25rem]">
+                    selected
+                </span>
+            </span>
+
+            <div className="h-4 w-px bg-border mx-1 shrink-o" aria-hidden />
+
+            {visibleActions.map((action) => (
+                <Button
+                    key={action.key}
+                    variant={action.variant ?? 'outline'}
+                    size='sm'
+                    className="h-7 gap-1.5 text-xs "
+
+                    onClick={() => action.onClick(selectedIds)}
+                >
+                    {action.icon}
+                    {action.label}
+                </Button>
+            ))}
+
+            {/* Clear selection button */}
+            <Button
+                variant='ghost'
+                size='sm'
+                className="h-7 gap-1 text-xs ml-auto text-muted-foreground hover:text-foreground"
+                onClick={onClearSelection}
+            >
+                <X className="h-3 w-3" />
+                Clear Selection
+            </Button>
+
+        </div>
+    )
+}

--- a/components/table/BulkActionBar.tsx
+++ b/components/table/BulkActionBar.tsx
@@ -35,23 +35,23 @@ export function BulkActionBar({
     return (
         <div className={cn(
         'animate-in slide-in-from-top-2 fade-in duration-200',
-        'flex items-center gap-3 rounded-md border border-border bg-muted/60 px-3 py-2 mb-2',
+        'flex items-center gap-3 rounded-md border border-border bg-muted/60 px-3 py-2 mb-2 ',
         className
       )}>
             <span className="flex items-center gap-1.5 text-sm font-medium text-foreground mr-1 shrink-0">
-                <span className="inline-flex items-center justify-center rounded bg-primary text-primary-foreground text-xs font-bold px-1.5 py-0.5 min-w-[1.25rem]">
+                <span className="inline-flex items-center justify-center rounded bg-primary text-primary-foreground text-xs font-bold px-1.5 py-0.5 min-w-[1.25rem] cursor-pointer">
                     selected
                 </span>
             </span>
 
-            <div className="h-4 w-px bg-border mx-1 shrink-o" aria-hidden />
+            <div className="h-4 w-px bg-border mx-1 shrink-o " aria-hidden />
 
             {visibleActions.map((action) => (
                 <Button
                     key={action.key}
                     variant={action.variant ?? 'outline'}
                     size='sm'
-                    className="h-7 gap-1.5 text-xs "
+                    className="h-7 gap-1.5 text-xs  cursor-pointer"
 
                     onClick={() => action.onClick(selectedIds)}
                 >
@@ -64,7 +64,7 @@ export function BulkActionBar({
             <Button
                 variant='ghost'
                 size='sm'
-                className="h-7 gap-1 text-xs ml-auto text-muted-foreground hover:text-foreground"
+                className="h-7 gap-1 text-xs ml-auto text-muted-foreground hover:text-foreground cursor-pointer"
                 onClick={onClearSelection}
             >
                 <X className="h-3 w-3" />

--- a/components/table/GenericMobileRow.tsx
+++ b/components/table/GenericMobileRow.tsx
@@ -2,6 +2,8 @@
 import { memo } from 'react'
 import { GenericCell } from './GenericCell'
 import { RowActions } from './RowActions'
+import { Check } from 'lucide-react'
+import { Checkbox } from '../ui/checkbox'
 
 type Header = {
     name: string
@@ -14,6 +16,8 @@ type RowDataBase = {
 }
 
 type GenericMobileRowProps = {
+    isSelected?: boolean
+    onToggleSelect: () => void
     activeTab: string
     isPatientTab: boolean
     isRemovedPatientsTab?: boolean
@@ -28,6 +32,8 @@ type GenericMobileRowProps = {
 // ✅ Mobile card row (not inside <table>)
 export const GenericMobileRow = memo(function GenericMobileRow(props: GenericMobileRowProps) {
     const {
+        isSelected = false,
+        onToggleSelect,
         activeTab,
         isPatientTab,
         rowData,
@@ -45,6 +51,13 @@ export const GenericMobileRow = memo(function GenericMobileRow(props: GenericMob
         >
             {/* <div className="text-muted-foreground text-sm">#{index + 1}</div> */}
             <div className="flex items-start justify-between">
+                <div className='absolute top-3 right-3'>
+                    <Checkbox 
+                        checked={isSelected}
+                        onCheckedChange={onToggleSelect}
+                        aria-label={`Select row ${index + 1}`}
+                     />
+                </div>
                 <div className="text-muted-foreground text-sm">#{index + 1}</div>
 
                 <RowActions

--- a/components/table/GenericRow.tsx
+++ b/components/table/GenericRow.tsx
@@ -3,6 +3,7 @@ import { TableCell, TableRow } from '@/components/ui/table'
 import { memo } from 'react'
 import { GenericCell } from './GenericCell'
 import { RowActions } from './RowActions'
+import { Checkbox } from '../ui/checkbox'
 
 type Header = {
   name: string
@@ -15,6 +16,8 @@ type RowDataBase = {
 }
 
 type GenericRowProps = {
+  isSelected?: boolean
+  onToggleSelect: () => void
   activeTab: string
   isPatientTab: boolean
   isRemovedPatientsTab?: boolean
@@ -29,6 +32,8 @@ type GenericRowProps = {
 // ✅ Only the desktop <tr>
 export const GenericRow = memo(function GenericRow(props: GenericRowProps) {
   const {
+    isSelected = false,
+    onToggleSelect,
     activeTab,
     isPatientTab,
     rowData,
@@ -43,16 +48,28 @@ export const GenericRow = memo(function GenericRow(props: GenericRowProps) {
     <TableRow
       key={rowData.id}
       onClick={() => onView(rowData)}
-      className="border-border hidden border-b font-light sm:table-row cursor-pointer hover:bg-muted/40 transition-colors"
->
+      data-selected={isSelected}
+      className={`border-border hidden border-b font-light sm:table-row cursor-pointer hover:bg-muted/40 transition-colors ${
+  isSelected ? 'bg-primary/5 dark:bg-primary/10' : ''
+}`}
+    >
+      <TableCell className="border-border border-r text-center">
+        <div className='flex items-center justify-center'>
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={onToggleSelect}
+            aria-label={`Select row ${index + 1}`}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      </TableCell>
       <TableCell className="border-border border-r text-center">{index + 1}</TableCell>
 
       {headers.map((header, index) => (
         <TableCell
           key={index}
-          className={`border-border border-r text-center ${
-            header.key === 'name' ? 'font-semibold' : ''
-          }`}
+          className={`border-border border-r text-center ${header.key === 'name' ? 'font-semibold' : ''
+            }`}
         >
           <GenericCell
             value={rowData[header.key]}
@@ -62,8 +79,8 @@ export const GenericRow = memo(function GenericRow(props: GenericRowProps) {
         </TableCell>
       ))}
 
-      <TableCell className="space-x-2 text-center" 
-                 onClick={(e) => e.stopPropagation()}
+      <TableCell className="space-x-2 text-center"
+        onClick={(e) => e.stopPropagation()}
       >
         <RowActions
           rowData={rowData}

--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -16,7 +16,7 @@ import DeleteEntityDialog from '@/components/dialogs/DeleteEntityDialog'
 import { hospitalFields, patientFields, SEARCH_FIELDS, userFields } from '@/constants'
 import { useSearch, useStats, useTableData } from '@/hooks'
 import { Hospital, Patient, UserDoc } from '@/schema'
-import { useCallback, useEffect, useMemo } from 'react'
+import { use, useCallback, useEffect, useMemo } from 'react'
 import ViewDetailsDialog from '../dialogs/ViewDetailsDialog'
 import { GenericPagination, GenericRow, GenericToolbar } from './'
 import { useTableStore } from '@/store'
@@ -24,9 +24,13 @@ import { useResponsiveRows } from '@/hooks/table/useResponsiveRows'
 import { TabDataMap, RowDataBase, ModalType } from '@/types/table/types'
 import { GenericMobileRow } from './GenericMobileRow'
 import TableSkeleton from '@/components/skeletons/TableSkeleton'
-import { ArrowUp, ArrowDown, ArrowUpDown } from 'lucide-react'
+import { ArrowUp, ArrowDown, ArrowUpDown ,Trash2, UserPlus, Download, } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useSorting, SORTABLE_KEYS } from '@/hooks/table/useSorting'
+import { BulkAction, BulkActionBar } from './BulkActionBar'
+import { useBulkSelectionStore } from '@/store/bulk-selection-store'
+import { Checkbox } from '../ui/checkbox'
+import BulkDeleteDialog from '../dialogs/BulkDeleteDialog'
 
 export function GenericTable({
     headers,
@@ -48,6 +52,8 @@ export function GenericTable({
     }
 
     const { selectedRow, modal, setSelectedRow, openModal, closeModal } = useTableStore()
+
+    const { selectedIds, toggleRow, selectAll, clearSelection, isSelected, selectedIdsArray, selectionCount } = useBulkSelectionStore()
 
     const queryProps = {
         orgId,
@@ -101,6 +107,7 @@ export function GenericTable({
         isHospitalTab,
     })
 
+    //clear selection when filters change or page changes
     useEffect(() => {
         setCurrentPage(1)
     }, [filteredPatients.length, setCurrentPage])
@@ -109,6 +116,12 @@ export function GenericTable({
     useEffect(() => {
         setCurrentPage(1)
     }, [sorting, setCurrentPage])
+    
+    useEffect(() => {
+        clearSelection()
+    }, [currentPage, searchFields, filteredPatients.length, clearSelection])
+
+
 
     const handleRowAction = useCallback(
         (row: RowDataBase, action: ModalType) => {
@@ -128,6 +141,47 @@ export function GenericTable({
         return data ?? []
     }
 
+    const currentPageIds = useMemo(() => paginatedData.map((row) => row.id), [paginatedData])
+    const allCurrentSelected = currentPageIds.length> 0 && currentPageIds.every((id) => selectedIds.has(id))
+    const someCurrentPageSelected = !allCurrentSelected && currentPageIds.some((id) => selectedIds.has(id))
+
+    const bulkActions: BulkAction[] = useMemo(() => [
+        {
+            key: 'delete',
+            label: 'Delete',
+            icon: <Trash2 className="h-3 w-3" />,   
+            variant: 'destructive',
+            onClick: (ids) => {
+                    openModal('bulkDelete')
+            }
+         },
+         {
+            key: 'Assign',
+            label: 'Assign',
+            icon: <UserPlus className="h-3 w-3" />,
+            onClick: (ids) => {
+                // handle assign action
+                console.log('Assigning IDs:', ids)
+            }
+         },
+         {
+            key: 'export',
+            label: 'Export',
+            icon: <Download className="h-3 w-3" />,
+            onClick: (ids) => {
+               
+                // handle export logic with exportData
+                console.log('Exporting data for IDs:', ids)
+            }   
+         }
+
+    ], [openModal, isPatientTab])
+
+
+    function selectectedCount(): number {
+        throw new Error('Function not implemented.')
+    }
+
     return (
         <div className="flex min-h-screen flex-col">
             <GenericToolbar
@@ -139,10 +193,30 @@ export function GenericTable({
                 isLoading={isLoading || isLoadingAuth}
             />
 
+            <BulkActionBar
+                selectedCount={selectionCount()}
+                selectedIds={selectedIdsArray()}
+                actions={bulkActions}
+                onClearSelection={clearSelection}
+            />
+
             <Table className="border-border flex-1 overflow-auto rounded-md border">
                 <TableHeader className="bg-muted hidden sm:table-header-group">
                     <TableRow className="border-border border-b">
-                        <TableHead className="border-border w-12 border-r text-center">
+                        {/* bulk actions */}
+                        <TableHead className="border-border w-12 border-r  text-center">
+                            <div className='flex items-center justify-center'>
+                                <Checkbox
+                                checked = {
+                                    allCurrentSelected ? true : someCurrentPageSelected ? 'indeterminate' : false
+                                }
+                                onCheckedChange={() => selectAll(currentPageIds)}
+                                aria-label='Select all rows on this page'
+                                />
+                            </div>
+                            
+                        </TableHead>
+                        <TableHead className="border-border w-12 border-r text-center items-center justify-center">
                             S/NO
                         </TableHead>
                         {headers.map((header, id) => {
@@ -218,6 +292,8 @@ export function GenericTable({
                                 onUpdate={(row) => handleRowAction(row, 'update')}
                                 onDelete={(row) => handleRowAction(row, 'delete')}
                                 headers={stableHeaders}
+                                isSelected={isSelected(data.id)}
+                                onToggleSelect={() => toggleRow(data.id)}
                             />
                         ))
                     ) : (
@@ -247,6 +323,8 @@ export function GenericTable({
                         onUpdate={(row) => handleRowAction(row, 'update')}
                         onDelete={(row) => handleRowAction(row, 'delete')}
                         headers={stableHeaders}
+                        isSelected={isSelected(data.id)}
+                        onToggleSelect={() => toggleRow(data.id)}
                     />
                 ))}
             </div>
@@ -277,6 +355,19 @@ export function GenericTable({
                 collectionName={activeTab} // 'patients' | 'hospitals' | 'doctors' | 'nurses' | 'ashas' | 'removedPatients'
                 onClose={closeModal}
             />
+
+             {/* Bulk delete confirmation dialog */}
+
+            <BulkDeleteDialog
+            open={modal === 'bulkDelete'}
+            collectionName={activeTab}
+            ids={selectedIdsArray()}
+            onClose={() =>{
+                closeModal(),
+                clearSelection()} }
+            
+            />
+           
         </div>
     )
 }

--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -185,9 +185,6 @@ export function GenericTable({
     ], [openModal, isPatientTab, exportSelected, data, stableHeaders, activeTab])
 
 
-    function selectectedCount(): number {
-        throw new Error('Function not implemented.')
-    }
 
     return (
         <div className="flex min-h-screen flex-col">
@@ -379,7 +376,7 @@ export function GenericTable({
             open={modal === 'bulkAssign'}
             ids={selectedIdsArray()}
             onClose={ () =>{
-                closeModal(),
+                closeModal()
                 clearSelection()}
                 
             }

--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -31,6 +31,8 @@ import { BulkAction, BulkActionBar } from './BulkActionBar'
 import { useBulkSelectionStore } from '@/store/bulk-selection-store'
 import { Checkbox } from '../ui/checkbox'
 import BulkDeleteDialog from '../dialogs/BulkDeleteDialog'
+import { useBulkExport } from '@/hooks/table/useBulkExport'
+import {BulkAssignDialog} from '../dialogs/BulkAssignDialog'
 
 export function GenericTable({
     headers,
@@ -54,6 +56,7 @@ export function GenericTable({
     const { selectedRow, modal, setSelectedRow, openModal, closeModal } = useTableStore()
 
     const { selectedIds, toggleRow, selectAll, clearSelection, isSelected, selectedIdsArray, selectionCount } = useBulkSelectionStore()
+    const { exportSelected } = useBulkExport()
 
     const queryProps = {
         orgId,
@@ -151,17 +154,18 @@ export function GenericTable({
             label: 'Delete',
             icon: <Trash2 className="h-3 w-3" />,   
             variant: 'destructive',
-            onClick: (ids) => {
+            onClick: () => {
                     openModal('bulkDelete')
             }
          },
          {
             key: 'Assign',
             label: 'Assign',
+            hidden: !isPatientTab, // only show for patients
             icon: <UserPlus className="h-3 w-3" />,
-            onClick: (ids) => {
+            onClick: () => {
                 // handle assign action
-                console.log('Assigning IDs:', ids)
+                openModal('bulkAssign')
             }
          },
          {
@@ -169,13 +173,16 @@ export function GenericTable({
             label: 'Export',
             icon: <Download className="h-3 w-3" />,
             onClick: (ids) => {
-               
-                // handle export logic with exportData
-                console.log('Exporting data for IDs:', ids)
+               exportSelected(
+                ids,
+                stableHeaders,
+                activeTab,
+                data as Record<string, unknown>[],
+               )
             }   
          }
 
-    ], [openModal, isPatientTab])
+    ], [openModal, isPatientTab, exportSelected, data, stableHeaders, activeTab])
 
 
     function selectectedCount(): number {
@@ -366,6 +373,16 @@ export function GenericTable({
                 closeModal(),
                 clearSelection()} }
             
+            />
+
+            <BulkAssignDialog
+            open={modal === 'bulkAssign'}
+            ids={selectedIdsArray()}
+            onClose={ () =>{
+                closeModal(),
+                clearSelection()}
+                
+            }
             />
            
         </div>

--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -366,6 +366,7 @@ export function GenericTable({
             open={modal === 'bulkDelete'}
             collectionName={activeTab}
             ids={selectedIdsArray()}
+            rowsData={paginatedData as Record<string, any>[]}
             onClose={() =>{
                 closeModal(),
                 clearSelection()} }

--- a/hooks/table/useBulkExport.ts
+++ b/hooks/table/useBulkExport.ts
@@ -1,24 +1,28 @@
-import { toast } from 'sonner'
-
 export type exportHeader = {
-    name: string
-    key: string
+    name: string  //column label in csv
+    key: string  //key to read from exportRow
 }
 
 type exportRow = Record<string, unknown>
 
-function toCSV(rows: exportRow[], headers: exportHeader[]): string {
-    const headerLine = headers.map((h) => `${h.name}`).join(',')
-    const dataLines = rows.map((row) =>
-        headers.map((h) => {
+function toCSV (rows: exportRow[], headers: exportHeader[]): string {
+
+    const HeaderLine = headers.map((h) => `${h.name}`).join(',') 
+
+    //wrap values in quotes and escape existing quotes
+    const DataLines = rows.map((row) => {
+        return headers.map((h) => {
             const value = row[h.key] ?? ''
-            return `"${String(value).replace(/"/g, '""')}"`
+            const escapedValue = String(value).replace(/"/g, '""')
+            return `"${escapedValue}"`
         }).join(',')
-    )
-    return [headerLine, ...dataLines].join('\n')
+    })
+
+    return [HeaderLine, ...DataLines].join('\n')
 }
 
-function downloadCSV(csv: string, filename: string) {
+
+function downloadCSV (csv: string, filename: string) {
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
@@ -30,26 +34,26 @@ function downloadCSV(csv: string, filename: string) {
     URL.revokeObjectURL(url)
 }
 
-export function useBulkExport() {
+export function useBulkExport () {
     function exportSelected(
         selectedIds: string[],
         headers: exportHeader[],
         collectionName: string,
         allData: exportRow[]
+
     ) {
-        if (!selectedIds.length) return
+        if(!selectedIds.length) return
 
-        const selectedRows = allData.filter((row) =>
-            selectedIds.includes(String(row.id))
-        )
+        // filter data to only include selected rows
+        const selectedRows = allData.filter( (row) => selectedIds.includes(String(row.id)) )
 
-        if (!selectedRows.length) return
+        if(!selectedRows.length) return
 
         const csv = toCSV(selectedRows, headers)
-        const date = new Date().toISOString().split('T')[0]
+        const date = new Date().toISOString().split('T')[0] // YYYY-MM-DD
         const filename = `${collectionName}_export_${date}.csv`
         downloadCSV(csv, filename)
-        toast.success(`${selectedRows.length} records exported`)
+
     }
 
     return { exportSelected }

--- a/hooks/table/useBulkExport.ts
+++ b/hooks/table/useBulkExport.ts
@@ -1,0 +1,56 @@
+import { toast } from 'sonner'
+
+export type exportHeader = {
+    name: string
+    key: string
+}
+
+type exportRow = Record<string, unknown>
+
+function toCSV(rows: exportRow[], headers: exportHeader[]): string {
+    const headerLine = headers.map((h) => `${h.name}`).join(',')
+    const dataLines = rows.map((row) =>
+        headers.map((h) => {
+            const value = row[h.key] ?? ''
+            return `"${String(value).replace(/"/g, '""')}"`
+        }).join(',')
+    )
+    return [headerLine, ...dataLines].join('\n')
+}
+
+function downloadCSV(csv: string, filename: string) {
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.setAttribute('download', filename)
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+}
+
+export function useBulkExport() {
+    function exportSelected(
+        selectedIds: string[],
+        headers: exportHeader[],
+        collectionName: string,
+        allData: exportRow[]
+    ) {
+        if (!selectedIds.length) return
+
+        const selectedRows = allData.filter((row) =>
+            selectedIds.includes(String(row.id))
+        )
+
+        if (!selectedRows.length) return
+
+        const csv = toCSV(selectedRows, headers)
+        const date = new Date().toISOString().split('T')[0]
+        const filename = `${collectionName}_export_${date}.csv`
+        downloadCSV(csv, filename)
+        toast.success(`${selectedRows.length} records exported`)
+    }
+
+    return { exportSelected }
+}

--- a/lib/patient/bulkDelete.ts
+++ b/lib/patient/bulkDelete.ts
@@ -1,0 +1,24 @@
+import { db } from "@/firebase";
+import {doc, writeBatch} from "firebase/firestore";
+
+export async function bulkDeletePatients(
+    ids: string[],
+    collectionNames: string
+): Promise<void> {
+    const BATCH_SIZE = 500; // Firestore batch limit
+    const chunks: string[][] = [];
+
+    for ( let i = 0; i < ids.length; i += BATCH_SIZE) {
+        chunks.push(ids.slice(i, i + BATCH_SIZE));
+    }
+
+    for (const chunk of chunks) {
+        const batch = writeBatch(db)
+        chunk.forEach((id) => {
+            const ref = doc(db, collectionNames, id);
+            batch.delete(ref);
+        })
+        await batch.commit();
+    }
+
+}

--- a/store/bulk-selection-store.ts
+++ b/store/bulk-selection-store.ts
@@ -1,0 +1,54 @@
+
+import { create } from "zustand";
+
+interface BulkSelectionState {
+    selectedIds: Set<string>;
+
+    isSelected: (id: string) => boolean;
+    selectionCount: () => number; // returns the count of selected rows
+    selectedIdsArray: () => string[];
+
+    toggleRow: (id: string) => void;
+    selectAll: (ids: string[]) => void; // accepts all IDs on the current page
+    clearSelection: () => void;
+}
+
+export const useBulkSelectionStore = create<BulkSelectionState>((set, get) => ({
+
+    selectedIds: new Set(),
+
+    isSelected: (id) => get().selectedIds.has(id),
+
+    selectionCount: () => get().selectedIds.size,
+
+    selectedIdsArray: () => Array.from(get().selectedIds),
+
+    toggleRow: (id) => set((state) => {
+        const next = new Set(state.selectedIds)
+        if(next.has(id)) {
+            next.delete(id)
+        } else {
+            next.add(id)
+        }
+        return { selectedIds: next }
+    }),
+
+    selectAll: (ids) => set((state) => {
+        const currentPageIds = new Set(ids);
+        const AllCurrentSelected = ids.every((id) => state.selectedIds.has(id));
+
+        if (AllCurrentSelected) {
+            // Deselect all if all are currently selected
+            const next = new Set(state.selectedIds)
+            currentPageIds.forEach((id) => next.delete(id));
+            return { selectedIds: next };
+        }
+
+        //  select all current page rows
+        const next = new Set(state.selectedIds);
+        ids.forEach((id) => next.add(id));
+        return { selectedIds: next };
+    }),
+
+    clearSelection: () => set({ selectedIds: new Set() })
+}))

--- a/store/table-store.ts
+++ b/store/table-store.ts
@@ -11,9 +11,9 @@ export const isUserDoc = (row: any): row is UserDoc => row && 'userId' in row
 
 interface TableState {
     selectedRow: TableRow
-    modal: 'view' | 'update' | 'delete' | 'bulkDelete' | null
+    modal: 'view' | 'update' | 'delete' | 'bulkDelete' | 'bulkAssign' | null
     setSelectedRow: (row: TableRow | null) => void
-    openModal: (type: 'view' | 'update' | 'delete' | 'bulkDelete') => void
+    openModal: (type: 'view' | 'update' | 'delete' | 'bulkDelete' | 'bulkAssign') => void
     closeModal: () => void
 }
 

--- a/store/table-store.ts
+++ b/store/table-store.ts
@@ -11,9 +11,9 @@ export const isUserDoc = (row: any): row is UserDoc => row && 'userId' in row
 
 interface TableState {
     selectedRow: TableRow
-    modal: 'view' | 'update' | 'delete' | null
+    modal: 'view' | 'update' | 'delete' | 'bulkDelete' | null
     setSelectedRow: (row: TableRow | null) => void
-    openModal: (type: 'view' | 'update' | 'delete') => void
+    openModal: (type: 'view' | 'update' | 'delete' | 'bulkDelete') => void
     closeModal: () => void
 }
 


### PR DESCRIPTION

#38 Implemented reusable bulk row selection architecture for patients table with initial support for bulk delete functionality.

**Changes Made**

- [x] Added centralized Zustand bulk selection store
- [x] Added row checkbox selection
- [x] Added select-all support for current page rows
- [x] Added reusable bulk action structure
- [x] Implemented bulk delete flow
- [x] Added Firestore batch delete utility
- [x] Added selection clearing/reset handling
- [x] Added selected-row UI state handling

<img width="1737" height="918" alt="Screenshot 2026-05-16 at 09 44 26" src="https://github.com/user-attachments/assets/9d56104b-04b0-41eb-9485-420b24297105" />
<img width="1187" height="602" alt="Screenshot 2026-05-16 at 09 44 37" src="https://github.com/user-attachments/assets/dc98e195-a1c1-4ff1-a343-56854af9e0ea" />