### PR TITLE
fix: filter patients by organization in doctor dashboard

### DIFF
--- a/data/users.mjs
+++ b/data/users.mjs
@@ -6,7 +6,7 @@ export const defaultUsers = [
     sex: "male",
     role: "admin",
     phoneNumber: "+919876543210",
-    orgId: "jipmer-main-001",
+    orgId: "jipmer-001",
     orgName: "JIPMER Puducherry"
   },
   {

--- a/hooks/table/useTableData.ts
+++ b/hooks/table/useTableData.ts
@@ -90,8 +90,12 @@ export const useTableData = ({ orgId, ashaId, enabled = true, requiredData }: Us
             queryFn: async () => {
                 let patientsQuery
                 if (orgId) {
-                    patientsQuery = query(collection(db, 'patients'))
-                } else if (ashaId) {
+                    patientsQuery = query(
+                    collection(db, 'patients'),
+                    where('assignedHospital.id', '==', orgId)
+                    )
+        }
+                 else if (ashaId) {
                     patientsQuery = query(
                         collection(db, 'patients'),
                         where('assignedAsha', '==', ashaId)


### PR DESCRIPTION
## 📄 Description

Fixed the patient filtering issue in the doctor dashboard where doctors were able to view patients belonging to all organizations/hospitals instead of only their assigned organization.

### ✅ Changes Made

* Added Firestore query filtering using:
  `where('assignedHospital.id', '==', orgId)`
* Normalized seeded `orgId` values in `data/users.mjs` to match hospital IDs used in patient records and hospital data.
* Ensured organization-based filtering works correctly for doctors.

### 🧪 Manual Testing

* Set up the project locally with Firebase Authentication and Firestore.
* Seeded users, hospitals, and patients locally.
* Verified that doctors only see patients belonging to their assigned hospital.
* Manually changed a patient's `assignedHospital.id` in Firestore and confirmed the patient disappeared from the doctor dashboard after refresh.

## 🔗 Related Issue

Closes #238

## 🔄 Type of Change

* [x] Bug fix

## ✅ Checklist

* [x] Code follows the project structure and conventions
* [x] Tested locally
* [x] Existing tests pass
* [x] No sensitive files or environment variables committed
* [x] Contributing under GSSoC '26

## 🎯 Program

GSSoC '26
