### PR TITLE
fix: improve patient view dialog - dates, fields and formatting

### DIFF
--- a/components/dialogs/ViewDetailsDialog.tsx
+++ b/components/dialogs/ViewDetailsDialog.tsx
@@ -1,14 +1,11 @@
 'use client'
-
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Patient } from '@/schema/patient'
 import { UserDoc } from '@/schema/user'
 import { Hospital } from '@/schema/hospital'
-
 type RowDataType = Patient | UserDoc | Hospital
 type FieldToDisplay = { label: string; key: string }
-
 export default function ViewDetailsDialog({
     open,
     onOpenChange,
@@ -23,7 +20,6 @@ export default function ViewDetailsDialog({
     function renderValue(key: string, value: any): string {
         if (value == null) return 'N/A'
         if (value === '') return 'N/A'
-
         if (Array.isArray(value)) {
             if (value.length === 0) return 'N/A'
             if (typeof value[0] === 'string') return value.join(', ')
@@ -31,23 +27,25 @@ export default function ViewDetailsDialog({
                 return value.map((v) => `${v.date || ''} - ${v.remarks || ''}`).join('; ')
             }
         }
-
         if (typeof value === 'object') {
             if (key === 'gpsLocation') return `Lat: ${value.lat}, Lng: ${value.lng}`
             if (key === 'assignedHospital') return `${value.name}`
             if (key === 'insurance') return `${value.type}${value.id ? ` (${value.id})` : ''}`
             return JSON.stringify(value)
         }
-
         if (typeof value === 'boolean') return value ? 'Yes' : 'No'
-
+        if (typeof value === 'number') {
+            if (key.toLowerCase().includes('date') || key.toLowerCase().includes('year')) {
+                const date = new Date((value - 25569) * 86400 * 1000)
+                return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
+            }
+            return String(value)
+        }
         if (typeof value === 'string') {
             return value.charAt(0).toUpperCase() + value.slice(1)
         }
-
         return String(value)
     }
-
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="bg-card text-card-foreground rounded-xl shadow-md sm:max-w-md">
@@ -85,7 +83,6 @@ export default function ViewDetailsDialog({
         </Dialog>
     )
 }
-
 function Info({ label, value }: { label: string; value: string }) {
     return (
         <div className="border-b border-border py-3 last:border-0">

--- a/components/dialogs/ViewDetailsDialog.tsx
+++ b/components/dialogs/ViewDetailsDialog.tsx
@@ -4,8 +4,13 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Patient } from '@/schema/patient'
 import { UserDoc } from '@/schema/user'
 import { Hospital } from '@/schema/hospital'
+import { db } from '@/firebase'
+import { doc, getDoc } from 'firebase/firestore'
+import { useEffect, useState } from 'react'
+
 type RowDataType = Patient | UserDoc | Hospital
 type FieldToDisplay = { label: string; key: string }
+
 export default function ViewDetailsDialog({
     open,
     onOpenChange,
@@ -17,7 +22,35 @@ export default function ViewDetailsDialog({
     rowData: RowDataType
     fieldsToDisplay: FieldToDisplay[]
 }) {
+    const [ashaName, setAshaName] = useState<string | null>(null)
+
+    useEffect(() => {
+        const ashaId = (rowData as Patient).assignedAsha
+        if (!ashaId || ashaId === 'none' || ashaId === '') {
+            setAshaName(null)
+            return
+        }
+        const fetchAshaName = async () => {
+            try {
+                const ashaDoc = await getDoc(doc(db, 'users', ashaId))
+                if (ashaDoc.exists()) {
+                    const data = ashaDoc.data()
+                    setAshaName(data.name || data.email || ashaId)
+                } else {
+                    setAshaName(ashaId)
+                }
+            } catch {
+                setAshaName(ashaId)
+            }
+        }
+        fetchAshaName()
+    }, [rowData])
+
     function renderValue(key: string, value: any): string {
+        if (key === 'assignedAsha') {
+            if (!value || value === 'none' || value === '') return 'N/A'
+            return ashaName ?? 'Loading...'
+        }
         if (value == null) return 'N/A'
         if (value === '') return 'N/A'
         if (Array.isArray(value)) {
@@ -46,6 +79,7 @@ export default function ViewDetailsDialog({
         }
         return String(value)
     }
+
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="bg-card text-card-foreground rounded-xl shadow-md sm:max-w-md">
@@ -83,6 +117,7 @@ export default function ViewDetailsDialog({
         </Dialog>
     )
 }
+
 function Info({ label, value }: { label: string; value: string }) {
     return (
         <div className="border-b border-border py-3 last:border-0">

--- a/constants/patient.ts
+++ b/constants/patient.ts
@@ -29,8 +29,8 @@ export const patientFields = [
     { label: 'HBCR ID', key: 'hbcrID' },
     { label: 'Hospital Registration ID', key: 'hospitalRegistrationId' },
     { label: 'Stage of the Cancer', key: 'stageOfTheCancer' },
-    { label: 'Reason of Removal', key: 'reasonOfRemoval' },
+    //   { label: 'Reason of Removal', key: 'reasonOfRemoval' },
     { label: 'Treatment Details', key: 'treatmentDetails' },
-    { label: 'Other Treatment Details', key: 'otherTreatmentDetails' },
+    //   { label: 'Other Treatment Details', key: 'otherTreatmentDetails' },
     { label: 'Insurance', key: 'insurance' }, // object {type, id}
 ]


### PR DESCRIPTION
Fixes #29

- Converts Excel serial number dates to readable format (e.g. 45890 → 17 May 2026)
- Empty fields now show N/A instead of being blank
- Empty arrays now show N/A instead of []
- Text values are now capitalized (e.g. female → Female, none → None)
- Hides 'Other Treatment Details' field as it's not needed
- Hides 'Reason of Removal' field as it should only show when patient is actually removed
- Assigned ASHA field now shows the ASHA worker's name instead of their Firestore document ID
- Fetches ASHA name from the `users` collection using the stored ID
- ASHA field falls back to email if name is unavailable, and to N/A if unassigned