### PR TITLE
chore: remove leftover console.log statements

### DIFF
--- a/__tests__/unit/schema/patient/caregiverNameField.test.ts
+++ b/__tests__/unit/schema/patient/caregiverNameField.test.ts
@@ -13,8 +13,6 @@ describe('PatientSchema - caregiverName field validation', () => {
             assignedHospital: { id: 'h1', name: 'Test Hospital' },
         })
 
-        console.log(result)
-
         expect(result.success).toBe(true)
     })
 

--- a/app/PuduCan/asha/page.tsx
+++ b/app/PuduCan/asha/page.tsx
@@ -19,9 +19,7 @@ function AshaPageContent() {
         ashaId: userId,
         enabled: !isLoadingAuth && !!user?.email,
         requiredData: 'patients' as const,
-    }
 
-    console.log('user asha:', user)
 
     const {
         data: patients = [],
@@ -31,9 +29,7 @@ function AshaPageContent() {
         data: Patient[]
         isLoading: boolean
         isError: boolean
-    }
 
-    console.log('Fetched patients for ASHA:', patients)
 
     if (isLoading || isLoadingAuth) {
         return (

--- a/app/PuduCan/asha/page.tsx
+++ b/app/PuduCan/asha/page.tsx
@@ -19,8 +19,7 @@ function AshaPageContent() {
         ashaId: userId,
         enabled: !isLoadingAuth && !!user?.email,
         requiredData: 'patients' as const,
-
-
+    }
     const {
         data: patients = [],
         isLoading,

--- a/app/PuduCan/asha/page.tsx
+++ b/app/PuduCan/asha/page.tsx
@@ -29,6 +29,7 @@ function AshaPageContent() {
         data: Patient[]
         isLoading: boolean
         isError: boolean
+    }
 
 
     if (isLoading || isLoadingAuth) {

--- a/components/dialogs/DeleteEntityDialog.tsx
+++ b/components/dialogs/DeleteEntityDialog.tsx
@@ -89,8 +89,6 @@ export default function DeleteEntityDialog<T extends WithIdAndName | null>({
             } else {
                 // direct delete for hospitals/users/removedPatients
                 const coll = mapToFirestoreCollection(collectionName)
-                console.log('coll:', coll)
-                console.log('id:', id)  
                 await deleteDoc(doc(db, coll, id))
             }
 

--- a/components/table/GenericToolbar.tsx
+++ b/components/table/GenericToolbar.tsx
@@ -145,7 +145,6 @@ export function GenericToolbar({
                             <DropdownMenuItem
                                 onSelect={(e) => {
                                     e.preventDefault() // ✅ stop default closing behavior if needed
-                                    console.log('inside import button')
                                     document.getElementById('file-upload')?.click()
                                 }}
                             >
@@ -158,7 +157,6 @@ export function GenericToolbar({
                             accept=".csv, .xlsx, .xls"
                             className="hidden"
                             onChange={(e) => {
-                                console.log('inside file upload')
                                 importData(e, queryClient)
                             }}
                         />

--- a/lib/import/importUtils.ts
+++ b/lib/import/importUtils.ts
@@ -136,9 +136,7 @@ const uploadToFirestore = async (rows: any[], activeTab: string, queryClient: an
             snap.forEach((doc) => {
                 const data = doc.data()
                 hospitalMap[data.name] = { id: doc.id, name: data.name }
-            })
-            console.log('hospitalMap:', hospitalMap)
-        }
+
 
         let successCount = 0
         const errors: { row: number; issues: string[]; rowData: any }[] = []

--- a/lib/import/importUtils.ts
+++ b/lib/import/importUtils.ts
@@ -137,6 +137,8 @@ const uploadToFirestore = async (rows: any[], activeTab: string, queryClient: an
                 const data = doc.data()
                 hospitalMap[data.name] = { id: doc.id, name: data.name }
 
+            })
+        }
 
         let successCount = 0
         const errors: { row: number; issues: string[]; rowData: any }[] = []


### PR DESCRIPTION
## Description
This PR removes leftover `console.log` debugging statements across the codebase to prevent console clutter and improve production code quality. 

## Files Modified:
- `app/PuduCan/asha/page.tsx`
- `components/table/GenericToolbar.tsx`
- `components/dialogs/DeleteEntityDialog.tsx`
- `lib/import/importUtils.ts`
- `__tests__/unit/schema/patient/caregiverNameField.test.ts`

## Type of Change
- [x] Code Cleanup / Refactoring
