### PR TITLE
Fix: Add autoComplete attributes to Login form fields

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -189,6 +189,7 @@ export default function LoginPage() {
                                 <Input
                                     placeholder="Email"
                                     type="email"
+                                    autoComplete="email"
                                     aria-label="Email"
                                     {...register('email')}
                                     className="h-11 border-gray-300 bg-gray-50 pl-9 focus-visible:ring-2 focus-visible:ring-emerald-500/40 dark:border-gray-700 dark:bg-gray-800/60"
@@ -208,6 +209,7 @@ export default function LoginPage() {
                                 <Input
                                     placeholder="Password"
                                     aria-label="Password"
+                                    autoComplete="current-password"
                                     type={showPassword ? 'text' : 'password'}
                                     {...register('password')}
                                     className="h-11 border-gray-300 bg-gray-50 pr-10 pl-9 focus-visible:ring-2 focus-visible:ring-emerald-500/40 dark:border-gray-700 dark:bg-gray-800/60"


### PR DESCRIPTION
## Summary
Added standard HTML `autoComplete` attributes to the authentication fields on the Login page to ensure reliable support for browser autofill and third-party password managers.

## Changes
- Appended `autoComplete="email"` to the email field in `app/login/page.tsx`.
- Appended `autoComplete="current-password"` to the password field in `app/login/page.tsx`.

## Linked Issue
Closes #261

## Testing
- Rendered the login page locally and inspected the DOM to confirm the attributes are successfully passed to the native input elements.
- Tested the form using standard browser autofill to verify credentials populate correctly into both fields.
