### PR TITLE
feat(patient): add ABHA ID validation with auto-formatting (#254)

### DIFF
--- a/components/forms/patient/columns/column-one/fields/AadhaarField.tsx
+++ b/components/forms/patient/columns/column-one/fields/AadhaarField.tsx
@@ -22,6 +22,14 @@ export default function AadhaarField({ form }: AadhaarFieldProps) {
             .replace(/\D/g, '') // remove non-digits
             .slice(0, 12) // max 12 digits
             .replace(/(\d{4})(?=\d)/g, '$1 ') // space after each 4 digits
+    const formatAbha = (val: string) =>
+        val
+            .replace(/\D/g, '')
+            .slice(0, 14)
+            .replace(/^(\d{2})(\d{0,4})(\d{0,4})(\d{0,4})$/,
+                (_: string, a: string, b: string, c: string, d: string) =>
+                    [a, b, c, d].filter(Boolean).join('-')
+            )
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const raw = e.target.value
@@ -82,8 +90,17 @@ export default function AadhaarField({ form }: AadhaarFieldProps) {
                         <FormControl>
                             <FloatingLabelInput
                                 {...field}
-                                label="Aabha Number"
+                                label="ABHA Number"
+                                value={formatAbha(field.value ?? '')}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    const digitsOnly = e.target.value
+                                        .replace(/\D/g, '')
+                                        .slice(0, 14)
+                                    field.onChange(digitsOnly)
+                                }}
                                 autoComplete="off"
+                                inputMode="numeric"
+                                maxLength={19}
                             />
                         </FormControl>
                         <FormMessage />

--- a/schema/patient.ts
+++ b/schema/patient.ts
@@ -52,7 +52,25 @@ export const PatientSchema = z
         patientStatus: z.enum(['Alive', 'Not Alive', 'Not Available']).optional(),
         patientDeathDate: z.string().optional(),
         // treatmentStatus: z.enum(['Ongoing', 'FollowUp', 'Stopped', 'Not Available']).optional(),
-        aabhaId: z.string().optional(),
+        // ABHA ID is 14 digits only
+        aabhaId: z
+            .string()
+            .optional()
+            .refine(
+                (val) => {
+                    if (!val || val.trim() === '') return true
+                    const digitsOnly = val.replace(/-/g, '')
+                    return /^\d{14}$/.test(digitsOnly)
+                },
+                { message: 'ABHA ID must be exactly 14 digits (e.g. 91-1234-5678-9012)' }
+            )
+            .refine(
+                (val) => {
+                    if (!val || val.trim() === '') return true
+                    return /^(\d{14}|\d{2}-\d{4}-\d{4}-\d{4})$/.test(val)
+                },
+                { message: 'ABHA ID format must be XXXXXXXXXXXXXX or XX-XXXX-XXXX-XXXX' }
+            ),
         diagnosedDate: z.string().optional(),
         diagnosedYearsAgo: z.string().optional(),
         // new fields after second meet


### PR DESCRIPTION
- Added strict length validation (exactly 14 digits) for the ABHA ID field in the patient Zod schema.

- Updated AadhaarField.tsx to automatically strip any alphabetic or special characters as the user types.

- Implemented real-time auto-formatting to display the ABHA ID in the official format (XX-XXXX-XXXX-XXXX).
- Closes #254 

- Added inputMode="numeric" to trigger the numeric keypad on mobile devices for a better user experience.
<img width="1527" height="767" alt="Screenshot 2026-05-19 214734" src="https://github.com/user-attachments/assets/877f0f49-5c1d-492c-b22b-c54bf4664e1a" />
<img width="1522" height="776" alt="Screenshot 2026-05-19 214654" src="https://github.com/user-attachments/assets/6e0a5c7b-0c98-4ec4-9baf-ca631e52fb09" />
