### PR TITLE
feat: replace admin tabs with dropdown (#255)

### DIFF
--- a/app/PuduCan/admin/page.tsx
+++ b/app/PuduCan/admin/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/button'
+
 import {
     HOSPITAL_TABLE_HEADERS,
     DOCTOR_TABLE_HEADERS,
@@ -86,34 +86,32 @@ function AdminPageContent() {
                 </Select>
             </div>
 
-            {/* Tablet+ : horizontal buttons */}
+  {/* All screens: dropdown + welcome banner */}
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex flex-wrap gap-2">
-                {(
-                    [
-                        'hospitals',
-                        'doctors',
-                        'nurses',
-                        'ashas',
-                        'patients',
-                        'removedPatients',
-                    ] as const
-                ).map((tab) => (
-                    <Button
-                        key={tab}
-                        onClick={() => handleTabChange(tab)}
-                        variant={'default'}
-                        className={`uppercase text-foreground ${activeTab === tab ? '' : 'bg-border'
-                            }`}
-                    >
-                        {tabLabels[tab]}
-                    </Button>
-                ))}
+                <Select value={activeTab} onValueChange={(val) => handleTabChange(val as typeof activeTab)}>
+                    <SelectTrigger className="w-48">
+                        <SelectValue placeholder="Select a section" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {(
+                            [
+                                'hospitals',
+                                'doctors',
+                                'nurses',
+                                'ashas',
+                                'patients',
+                                'removedPatients',
+                            ] as const
+                        ).map((tab) => (
+                            <SelectItem key={tab} value={tab}>
+                                {tabLabels[tab]}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+
+                <WelcomeBanner />
             </div>
-
-            <WelcomeBanner />
-
-        </div> 
             
 
             {/* Table */ }

--- a/app/PuduCan/admin/page.tsx
+++ b/app/PuduCan/admin/page.tsx
@@ -61,35 +61,12 @@ function AdminPageContent() {
 
     return (
         <div className="mx-auto px-4 py-4 lg:max-w-[1240px] xl:max-w-[1400px]">
-            {/* Mobile: dropdown */}
-            <div className="mb-1 sm:hidden">
-                <Select value={activeTab} onValueChange={(val) => handleTabChange(val as typeof activeTab)}>
-                    <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select a section" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {(
-                            [
-                                'hospitals',
-                                'doctors',
-                                'nurses',
-                                'ashas',
-                                'patients',
-                                'removedPatients',
-                            ] as const
-                        ).map((tab) => (
-                            <SelectItem key={tab} value={tab}>
-                                {tabLabels[tab]}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-            </div>
+         
 
   {/* All screens: dropdown + welcome banner */}
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <Select value={activeTab} onValueChange={(val) => handleTabChange(val as typeof activeTab)}>
-                    <SelectTrigger className="w-48">
+                    <SelectTrigger className="w-48 focus:ring-0 focus-visible:ring-0 focus-visible:outline-none">
                         <SelectValue placeholder="Select a section" />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
Closes #255

Replaced the green tab buttons in the admin view with a simple 
dropdown selector that works across all screen sizes.
Removed the separate mobile-only dropdown since one unified 
dropdown now handles all breakpoints.