### PR TITLE
fix: allow admins to view all patients in Admin table

### DIFF
--- a/components/table/GenericTable.tsx
+++ b/components/table/GenericTable.tsx
@@ -59,7 +59,8 @@ export function GenericTable({
     const { exportSelected } = useBulkExport()
 
     const queryProps = {
-        orgId,
+        // Admins should see all patients (no org filter).
+        orgId: role === 'admin' ? null : orgId,
         ashaId: role === 'asha' ? user?.id : null,
         enabled: !isLoadingAuth,
         requiredData: activeTab,


### PR DESCRIPTION
## Summary
Ensure admin users can view all patient records in the **Admin → Patients** table by removing the organization-level filter when the current user role is `admin`.

This fixes an issue where passing `orgId` into the query caused Firestore to return zero patient records for admin sessions.

---

## Changes Made

- Updated `GenericTable.tsx`
- Modified query props so that `orgId` becomes `null` for admin users

```ts
orgId: role === "admin" ? null : orgId
````

---

## Why This Change?

Admins are expected to have access to site-wide patient data.

Previously, the patients query applied a Firestore filter on:

```ts
assignedHospital.id == orgId
```

Because admins should not be restricted to a single organization, this filter prevented patient data from appearing in the admin dashboard.

This change ensures:

* Admins fetch the complete `patients` collection
* Non-admin users continue to receive scoped data based on their organization or ASHA assignment

---

## Manual Testing

1. Start the development server:

```bash
pnpm dev
```

or

```bash
npm run dev
```

2. Sign in using an admin account
   Example: `admin@gmail.com`

3. Navigate to:

```txt
/PuduCan/admin
```

4. Open the **Patients** tab

5. Verify that patient rows are now visible

6. Sign in using a non-admin account (doctor / nurse / asha)

7. Confirm that data remains correctly scoped to their organization or assigned records

---

## Checklist

* [x] Code compiles successfully
* [x] Development server runs correctly
* [x] Admin users can view patient records
* [x] Non-admin filtering behavior remains unchanged
* [x] Optional changelog note added

---

### Closes

Closes #333

---

## Before

<img width="1918" height="870" alt="Admin Patients Table Issue" src="https://github.com/user-attachments/assets/d0c37945-4a7b-4075-9d6a-b3d06532e965" />

---

## After

<img width="1913" height="872" alt="Patients Table Fixed" src="https://github.com/user-attachments/assets/d469e919-fc32-4f97-bc56-d1ab8d29afe0" />