### PR TITLE
fix(auth): gate Firestore queries behind authenticated user to preven…

### DIFF
--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { FOOTER_GROUPS } from '@/constants/footer'
+import { auth } from '@/firebase'
+import { onAuthStateChanged, User as FirebaseUser } from 'firebase/auth'
 import { useEffect, useState } from 'react'
 import { getPaperSavedCount, calculateSheetsSaved } from '@/lib/papersaved'
 
@@ -8,11 +10,20 @@ export default function Footer() {
     const [sheetsSaved, setSheetsSaved] = useState<number | null>(null)
 
     useEffect(() => {
-        getPaperSavedCount().then((count) => {
-            if (count > 0) {
-                setSheetsSaved(calculateSheetsSaved(count))
+        // Only run the aggregation query once we know there is an
+        // authenticated user to avoid Firestore permission-denied errors.
+        const unsubscribe = onAuthStateChanged(auth, (user: FirebaseUser | null) => {
+            if (user) {
+                getPaperSavedCount().then((count) => {
+                    if (count > 0) {
+                        setSheetsSaved(calculateSheetsSaved(count))
+                    }
+                })
+            } else {
+                setSheetsSaved(null)
             }
         })
+        return () => unsubscribe()
     }, [])
 
     return (

--- a/hooks/table/useTableData.ts
+++ b/hooks/table/useTableData.ts
@@ -31,7 +31,7 @@ type UsePatientsProps = {
 
 export const useTableData = ({ orgId, ashaId, enabled = true, requiredData }: UsePatientsProps) => {
     // console.log('inside custom user hook')
-    const isPatientsEnabled = requiredData === 'patients' ? true : enabled && (!!orgId || !!ashaId)
+    const isPatientsEnabled = enabled && (requiredData === 'patients' ? true : (!!orgId || !!ashaId))
     const isHospitalsEnabled = enabled && requiredData === 'hospitals'
     const isUsersEnabled =
         enabled &&
@@ -136,6 +136,7 @@ export const useTableData = ({ orgId, ashaId, enabled = true, requiredData }: Us
                     ...doc.data(),
                 })) as Patient[]
             },
+            enabled: enabled,
             staleTime: 60 * 1000,
         })
         return patientsQuery

--- a/lib/papersaved.ts
+++ b/lib/papersaved.ts
@@ -1,9 +1,19 @@
-import { db } from '@/firebase'
+import { auth, db } from '@/firebase'
 import { collection, getCountFromServer } from 'firebase/firestore'
 
 const PAGES_PER_RECORD = 10
 
+/**
+ * Returns the number of patient records from Firestore.
+ * Only runs when Firebase Auth has a signed-in user; returns 0 otherwise
+ * to prevent permission-denied errors on unauthenticated requests.
+ */
 export async function getPaperSavedCount(): Promise<number> {
+    // Guard: do not run the aggregation query before auth is initialised
+    // or when there is no authenticated user.
+    const currentUser = auth?.currentUser
+    if (!currentUser) return 0
+
     try {
         const snapshot = await getCountFromServer(collection(db, 'patients'))
         return snapshot.data().count


### PR DESCRIPTION
closes #321 

Root cause : Firestore was throwing permission-denied errors because some database queries were running before the user was logged in.

Changes Made
Added auth check using onAuthStateChanged() ,query now runs only after user login is confirmed
If no user is logged in, it skips the query

Added auth.currentUser check .Returns 0 immediately if user is not logged in which prevents unauthorized Firestore requests

Both queries now properly respect the enabled flag prevents unnecessary Firestore calls before data/auth is ready