### PR TITLE
fix(ui): bypass global loader in handleAnchorClick for external and hash links

### DIFF
--- a/app/home/NavigationLoading.tsx
+++ b/app/home/NavigationLoading.tsx
@@ -16,6 +16,17 @@ export default function NavigationLoading() {
     useEffect(() => {
         const handleAnchorClick = (event: Event) => {
             const target = event.currentTarget as HTMLAnchorElement
+
+            if(!target.href) return
+
+            if(target.target === '_blank') return
+
+            const targetUrl = new URL(target.href , window.location.href)
+            if(targetUrl.hostname !== window.location.hostname) return
+
+            if(targetUrl.pathname === window.location.pathname && targetUrl.hash) return
+
+            
             if (target.href) {
                 setIsLoading(true)
             }


### PR DESCRIPTION
Closes #363 

### Description of Changes
The root cause of the infinite loading screen was within the global `handleAnchorClick` routing function. The handler was intercepting click events across all anchor (`<a>`) tags to trigger a Next.js route-transition animation spinner. However, it lacked conditional boundaries to determine if a link was navigating away from the core application or jumping to a section on the same page.

When a user clicked a partner hospital link, the loader activated on the current tab, but since the target opened in a new window (`_blank`), the router never completed an internal page transition to clear or turn off the spinner state.

**Fix implemented:**
- Updated `handleAnchorClick` to extract and inspect the target anchor's `href` and `target` attributes.
- Added explicit guard checks: if the link points to an external origin (e.g., doesn't match the current window location) or targets a same-page fragment identifier (`#`), the handler returns early and skips activating the global router loader state.

### Visuals

https://github.com/user-attachments/assets/b1edd0fc-817f-4d73-a1e4-9d5c007c010c


---

### Testing Methodology
1. Ran `pnpm dev` locally and cleared any cached states.
2. Verified standard internal routes (e.g., Logging in, Dashboard navigation) still trigger the transition loader perfectly.
3. Clicked external hospital links on the homepage footer; the target links opened cleanly in a new tab while the original PuduCan interface remained fully active and interactive.
4. Clicked same-page section links; page scrolled smooth-into-view without triggering loaders.

### Checklist
- [x] My code follows the repository code style guidelines.
- [x] I have verified the fix locally on my machine.
- [x] Running `pnpm lint` passes on my piece of code.