### PR TITLE
fix(ui): prevent global loading spinner on external link navigation for #363

### DIFF
--- a/app/home/NavigationLoading.tsx
+++ b/app/home/NavigationLoading.tsx
@@ -16,7 +16,24 @@ export default function NavigationLoading() {
     useEffect(() => {
         const handleAnchorClick = (event: Event) => {
             const target = event.currentTarget as HTMLAnchorElement
+            
             if (target.href) {
+                // 1. Skip if the link opens in a new tab
+                if (target.target === '_blank') return
+
+                // 2. Skip if it is an external link by comparing host names
+                const currentHost = window.location.host
+                try {
+                    const url = new URL(target.href)
+                    if (url.host !== currentHost) return
+                } catch {
+                    // Fallback if URL parsing fails
+                    return
+                }
+
+                // 3. Skip if it is an internal page anchor hash (e.g., href="#section")
+                if (target.getAttribute('href')?.startsWith('#')) return
+
                 setIsLoading(true)
             }
         }


### PR DESCRIPTION
### Description
Resolves #363. This PR fixes the issue where clicking external partner or hospital links triggers an indefinite global loading state on the homepage tab. 

### Changes Made
- Updated `NavigationLoading.tsx` to analyze anchor tag destinations before firing the global spinner state.
- Prevented loading hooks from executing if `target="_blank"`, if the anchor link points to a different host domain, or if it's an internal target hash pointer (`#`).

### Verification
Tested locally on `http://localhost:3000`. External partner links open cleanly in a new tab while the original homepage tab remains completely active and responsive.