### PR TITLE
fix: vertically center sustainability tip with logo in navbar

### DIFF
--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -25,7 +25,7 @@ export default function Navbar() {
         <div>
             <nav className="bg-background flex items-center justify-between border-b px-4 py-3 shadow md:px-8">
                 {/* Logo + Sustainability Tip */}
-                <div className="flex items-end gap-3">
+                <div className="flex items-center gap-3">
                     <Link href="/" className="text-2xl font-bold text-green-600">
                         PuduCan
                     </Link>


### PR DESCRIPTION
Fixes #388

Changed `items-end` to `items-center` on the navbar's logo container (`components/layout/Navbar.tsx`) so the Sustainability Tip aligns vertically centered with the PuduCan logo, instead of being bottom-aligned.