### PR TITLE
refactor: improve add patient form step layouts to responsive grid

### DIFF
--- a/components/forms/patient/columns/column-five/ColumnFive.tsx
+++ b/components/forms/patient/columns/column-five/ColumnFive.tsx
@@ -168,8 +168,8 @@ export function ColumnFive({ form, isAsha }: { form: any; isAsha?: boolean }) {
     return (
         <div
             className={clsx(
-                'flex w-full flex-col gap-4 sm:border-l-2 md:w-1/2 md:pl-4 lg:w-1/3',
-                isAsha && 'mx-auto border-none px-2 md:w-2/3 lg:w-full'
+                'grid w-full grid-cols-1 gap-6 md:grid-cols-2',
+                isAsha && 'mx-auto px-2'
             )}
         >
             {/* --- Follow-Ups Section --- */}

--- a/components/forms/patient/columns/column-four/ColumnFour.tsx
+++ b/components/forms/patient/columns/column-four/ColumnFour.tsx
@@ -25,135 +25,132 @@ export function ColumnFour({ form, isAsha = false }: RightColumnProps) {
 
     return (
         !suspectedCase && (
-            <div className={clsx('flex w-full flex-col sm:border-l-2 md:pl-4 gap-4 md:w-1/2 lg:w-1/3', isAsha && 'md:w-2/3 lg:w-full border-none px-2 mx-auto')} >
-                <TreatmentPeriodField form={form} />
-                <FormField
-                    control={control}
-                    name="hospitalRegistrationNumber"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormControl>
-                                <FloatingLabelInput
-                                    id="hospital-registration-number"
-                                    label="Hospital Registration Number"
-                                    autoComplete="off"
-                                    {...field}
-                                />
-                                {/* <Input
-                                    placeholder="Hospital Registration Number"
-                                    autoComplete="off"
-                                    {...field}
-                                /> */}
-                            </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={control}
-                    name="hbcrID"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormControl>
-                                <FloatingLabelInput
-                                    label="Enter HBCR ID"
-                                    autoComplete="off"
-                                    {...field}
-                                />
-                                {/* <Input placeholder="Enter HBCR ID" autoComplete="off" {...field} /> */}
-                            </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <div className="flex flex-col gap-2">
-                    <FormLabel className="text-muted-foreground text-sm">Stage of the Cancer</FormLabel>
-
+            <div className={clsx(
+                'grid w-full grid-cols-1 gap-6 md:grid-cols-2',
+                isAsha && 'px-2 mx-auto'
+            )}>
+                <div className="space-y-4">
+                    <TreatmentPeriodField form={form} />
                     <FormField
                         control={control}
-                        name="stageOfTheCancer.stage"
-                        defaultValue="Stage I"
+                        name="hospitalRegistrationNumber"
                         render={({ field }) => (
                             <FormItem>
                                 <FormControl>
-                                    <Select value={field.value ?? ''} onValueChange={(v) => field.onChange(v === '' ? undefined : v)}>
-                                        <SelectTrigger className="w-full" required>
-                                            <SelectValue>
-                                                {field.value ? (
-                                                    <span className="font-medium">{field.value}</span>
-                                                ) : (
-                                                    'Select cancer stage'
-                                                )}
-                                            </SelectValue>
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="Stage 0">Stage 0</SelectItem>
-                                            <SelectItem value="Stage I">Stage I</SelectItem>
-                                            <SelectItem value="Stage II">Stage II</SelectItem>
-                                            <SelectItem value="Stage III">Stage III</SelectItem>
-                                            <SelectItem value="Stage IV">Stage IV</SelectItem>
-                                        </SelectContent>
-                                    </Select>
+                                    <FloatingLabelInput
+                                        id="hospital-registration-number"
+                                        label="Hospital Registration Number"
+                                        autoComplete="off"
+                                        {...field}
+                                    />
                                 </FormControl>
                                 <FormMessage />
                             </FormItem>
                         )}
                     />
-
                     <FormField
                         control={control}
-                        name="stageOfTheCancer.subStage"
-                        defaultValue="None"
+                        name="hbcrID"
                         render={({ field }) => (
                             <FormItem>
                                 <FormControl>
-                                    <Select value={field.value ?? ''} onValueChange={(v) => field.onChange(v === '' || v === 'None' ? undefined : v)}>
-                                        <SelectTrigger className="w-full">
-                                            <SelectValue>
-                                                {field.value ? (
-                                                    <span className="font-medium">{field.value}</span>
-                                                ) : (
-                                                    'Select sub-stage (optional)'
-                                                )}
-                                            </SelectValue>
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="None">None</SelectItem>
-                                            <SelectItem value="A">A</SelectItem>
-                                            <SelectItem value="B">B</SelectItem>
-                                            <SelectItem value="C">C</SelectItem>
-                                            <SelectItem value="D">D</SelectItem>
-                                        </SelectContent>
-                                    </Select>
+                                    <FloatingLabelInput
+                                        label="Enter HBCR ID"
+                                        autoComplete="off"
+                                        {...field}
+                                    />
                                 </FormControl>
                                 <FormMessage />
                             </FormItem>
                         )}
                     />
                 </div>
-                <FormField
-                    control={control}
-                    name="biopsyNumber"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormControl>
-                                <FloatingLabelInput
-                                    label="Biopsy Number (If Applicable)"
-                                    autoComplete="off"
-                                    {...field}
-                                />
-                                {/* <Input
-                                    placeholder="Biopsy Number (If Applicable)"
-                                    autoComplete="off"
-                                    {...field}
-                                /> */}
-                            </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
 
-                <TreatmentDropdown form={form} />
+                <div className="space-y-4">
+                    <div className="flex flex-col gap-2">
+                        <FormLabel className="text-muted-foreground text-sm">Stage of the Cancer</FormLabel>
+
+                        <FormField
+                            control={control}
+                            name="stageOfTheCancer.stage"
+                            defaultValue="Stage I"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <Select value={field.value ?? ''} onValueChange={(v) => field.onChange(v === '' ? undefined : v)}>
+                                            <SelectTrigger className="w-full" required>
+                                                <SelectValue>
+                                                    {field.value ? (
+                                                        <span className="font-medium">{field.value}</span>
+                                                    ) : (
+                                                        'Select cancer stage'
+                                                    )}
+                                                </SelectValue>
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="Stage 0">Stage 0</SelectItem>
+                                                <SelectItem value="Stage I">Stage I</SelectItem>
+                                                <SelectItem value="Stage II">Stage II</SelectItem>
+                                                <SelectItem value="Stage III">Stage III</SelectItem>
+                                                <SelectItem value="Stage IV">Stage IV</SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={control}
+                            name="stageOfTheCancer.subStage"
+                            defaultValue="None"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <Select value={field.value ?? ''} onValueChange={(v) => field.onChange(v === '' || v === 'None' ? undefined : v)}>
+                                            <SelectTrigger className="w-full">
+                                                <SelectValue>
+                                                    {field.value ? (
+                                                        <span className="font-medium">{field.value}</span>
+                                                    ) : (
+                                                        'Select sub-stage (optional)'
+                                                    )}
+                                                </SelectValue>
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="None">None</SelectItem>
+                                                <SelectItem value="A">A</SelectItem>
+                                                <SelectItem value="B">B</SelectItem>
+                                                <SelectItem value="C">C</SelectItem>
+                                                <SelectItem value="D">D</SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    </div>
+                    <FormField
+                        control={control}
+                        name="biopsyNumber"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormControl>
+                                    <FloatingLabelInput
+                                        label="Biopsy Number (If Applicable)"
+                                        autoComplete="off"
+                                        {...field}
+                                    />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    <TreatmentDropdown form={form} />
+                </div>
             </div>
         )
     )

--- a/components/forms/patient/columns/column-one/ColumnOne.tsx
+++ b/components/forms/patient/columns/column-one/ColumnOne.tsx
@@ -16,12 +16,18 @@ interface LeftColumnProps {
 
 export function ColumnOne({ form, isAsha = false }: LeftColumnProps) {
     return (
-        <div className={clsx('flex w-full flex-col gap-4 md:w-1/2 lg:w-1/3', isAsha && 'md:w-2/3 lg:w-full px-2 mx-auto')}>
-            <NameField form={form} />
-            <ReligionDropdown form={form} />
-
-            <AadhaarField form={form} />
-            <PhoneNumbersField form={form} />
+        <div className={clsx(
+            'grid w-full grid-cols-1 gap-6 md:grid-cols-2',
+            isAsha && 'px-2 mx-auto'
+        )}>
+            <div className="space-y-4">
+                <NameField form={form} />
+                <ReligionDropdown form={form} />
+            </div>
+            <div className="space-y-4">
+                <AadhaarField form={form} />
+                <PhoneNumbersField form={form} />
+            </div>
         </div>
     )
 }

--- a/components/forms/patient/columns/column-three/ColumnThree.tsx
+++ b/components/forms/patient/columns/column-three/ColumnThree.tsx
@@ -15,40 +15,47 @@ export function ColumnThree({ form, isAsha }: RightColumnProps) {
     const { watch, control } = useFormContext()
 
     return (
-        <div className={clsx('flex w-full flex-col gap-4 md:w-1/2 lg:w-1/3', isAsha && 'md:w-2/3 lg:w-full px-2 mx-auto')}>
-            {/* Wrapped inside FormField for showing required alert messages. */}
-            <FormField
-                control={form.control}
-                name="diseases"
-                render={() => (
-                    <FormItem>
-                        <FormControl>
-                            <DiseaseMultiSelect sex={watch('sex')} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                )}
-            />
+        <div className={clsx(
+            'grid w-full grid-cols-1 gap-6 md:grid-cols-2',
+            isAsha && 'px-2 mx-auto'
+        )}>
+            <div className="space-y-4">
+                {/* Wrapped inside FormField for showing required alert messages. */}
+                <FormField
+                    control={form.control}
+                    name="diseases"
+                    render={() => (
+                        <FormItem>
+                            <FormControl>
+                                <DiseaseMultiSelect sex={watch('sex')} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
 
-            <RationCardSelect control={control} />
+                <RationCardSelect control={control} />
+            </div>
 
-            <FormField
-                control={form.control}
-                name="assignedHospital"
-                render={({ field }) => (
-                    <FormItem>
-                        <FormLabel className="text-muted-foreground text-sm">
-                            Assigned Hospital
-                        </FormLabel>
-                        <FormControl>
-                            <HospitalSearch value={field.value} onChange={field.onChange} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                )}
-            />
+            <div className="space-y-4">
+                <FormField
+                    control={form.control}
+                    name="assignedHospital"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel className="text-muted-foreground text-sm">
+                                Assigned Hospital
+                            </FormLabel>
+                            <FormControl>
+                                <HospitalSearch value={field.value} onChange={field.onChange} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
 
-            <DiagnosisTimingField form={form} />
+                <DiagnosisTimingField form={form} />
+            </div>
         </div>
     )
 }

--- a/components/forms/patient/columns/column-two/ColumnTwo.tsx
+++ b/components/forms/patient/columns/column-two/ColumnTwo.tsx
@@ -17,50 +17,57 @@ export function ColumnTwo({ form, isAsha }: MiddleColumnProps) {
     const { register, control } = form
 
     return (
-        <div className={clsx('flex flex-col gap-4 md:px-4 sm:border-x-2 md:w-1/2 lg:w-1/3', isAsha && 'md:w-2/3 lg:w-full px-2 mx-auto border-none')}>
-            <RegistrationDateField form={form} />
-            {/* Address */}
-            <FormField
-                control={control}
-                name="address"
-                render={({ field }) => (
-                    <FormItem>
-                        <FormControl>
-                            <FloatingLabelInput
-                                {...field}
-                                label="Address"
-                                autoComplete="off"
-                                className="!border-red-400"
-                            />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                )}
-            />
+        <div className={clsx(
+            'grid w-full grid-cols-1 gap-6 md:grid-cols-2',
+            isAsha && 'px-2 mx-auto border-none'
+        )}>
+            <div className="space-y-4">
+                <RegistrationDateField form={form} />
+                {/* Address */}
+                <FormField
+                    control={control}
+                    name="address"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormControl>
+                                <FloatingLabelInput
+                                    {...field}
+                                    label="Address"
+                                    autoComplete="off"
+                                    className="!border-red-400"
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
 
-            {/* Insurance */}
-            <InsuranceInfo form={form} />
+                {/* Insurance */}
+                <InsuranceInfo form={form} />
+            </div>
 
-            {/* DOB or Age */}
-            <DobOrAgeField form={form} />
+            <div className="space-y-4">
+                {/* DOB or Age */}
+                <DobOrAgeField form={form} />
 
-            {/* Sex */}
-            {/* wrapped inside formfield for showing required alert messages.*/}
-            <FormField
-                control={control}
-                name="sex"
-                render={() => (
-                    <FormItem>
-                        <FormControl>
-                            <SexSelect control={control} />
-                        </FormControl>
-                        <FormMessage />
-                    </FormItem>
-                )}
-            />
+                {/* Sex */}
+                {/* wrapped inside formfield for showing required alert messages.*/}
+                <FormField
+                    control={control}
+                    name="sex"
+                    render={() => (
+                        <FormItem>
+                            <FormControl>
+                                <SexSelect control={control} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
 
-            {/* Status */}
-            <PatientStatusSelect control={control} form={form} />
+                {/* Status */}
+                <PatientStatusSelect control={control} form={form} />
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
Closes #387

### Description
While checking the Add Patient form wizard, I noticed that the individual step components (`ColumnOne` through `ColumnFive`) still had legacy layout styling (like fixed vertical borders and narrow width constraints) left over from when all five columns were shown side-by-side on desktop. This caused fields to feel unnecessarily squeezed and look cramped on smaller viewports.

To fix this and make the form fully adaptive, I refactored the layout structure of all five step components:
* **Removed Legacy Constraints**: Cleaned up the hardcoded width overrides (`md:w-1/2 lg:w-1/3`) and removed the vertical divider borders between column steps so each step now occupies the full container space naturally.
* **Responsive Grid Transition**: Converted each step's layout to a responsive two-column grid (`grid-cols-1 md:grid-cols-2`). The input fields stack vertically on mobile screens for easy typing, and expand to a clean, spacious double-column layout on larger screens.
* **Verification**: Verified everything compiles cleanly via a production build (`npm run build`) and ran local visual inspections inside the browser to verify form padding, alignment, and responsiveness.

This makes patient data entry much more intuitive and responsive across screen sizes. Let me know if you'd like any visual adjustments!
